### PR TITLE
chore(app): use enum for isLoadingPassport type instead of "boolean | undefined"

### DIFF
--- a/app/__test-fixtures__/contextTestHelpers.tsx
+++ b/app/__test-fixtures__/contextTestHelpers.tsx
@@ -1,5 +1,5 @@
 import { UserContext, UserContextState } from "../context/userContext";
-import { CeramicContext, CeramicContextState } from "../context/ceramicContext";
+import { CeramicContext, CeramicContextState, IsLoadingPassportState } from "../context/ceramicContext";
 import { STAMP_PROVIDERS } from "../config/providers";
 import { mockAddress, mockWallet } from "./onboardHookValues";
 import React from "react";
@@ -25,7 +25,7 @@ export const makeTestCeramicContext = (initialState?: Partial<CeramicContextStat
       expiryDate: new Date(),
       stamps: [],
     },
-    isLoadingPassport: false,
+    isLoadingPassport: IsLoadingPassportState.Idle,
     allProvidersState: {
       Google: {
         providerSpec: STAMP_PROVIDERS.Google,

--- a/app/__tests__/components/Card.test.tsx
+++ b/app/__tests__/components/Card.test.tsx
@@ -8,7 +8,7 @@ import { Card, CardProps } from "../../components/Card";
 
 import { UserContextState } from "../../context/userContext";
 import { ProviderSpec } from "../../config/providers";
-import { CeramicContextState } from "../../context/ceramicContext";
+import { CeramicContextState, IsLoadingPassportState } from "../../context/ceramicContext";
 import { makeTestCeramicContext, renderWithContext } from "../../__test-fixtures__/contextTestHelpers";
 
 jest.mock("../../utils/onboard.ts");
@@ -36,7 +36,7 @@ beforeEach(() => {
 describe("when the passport is loading", () => {
   beforeEach(() => {
     // set up in a loading state...
-    mockCeramicContext.isLoadingPassport = true;
+    mockCeramicContext.isLoadingPassport = IsLoadingPassportState.Loading;
     // set up Some provider without a VC
     cardProps = {
       providerSpec: { name: "Some", description: "Some desc" } as ProviderSpec,

--- a/app/__tests__/pages/Dashboard.test.tsx
+++ b/app/__tests__/pages/Dashboard.test.tsx
@@ -12,7 +12,7 @@ import {
   makeTestUserContext,
   renderWithContext,
 } from "../../__test-fixtures__/contextTestHelpers";
-import { CeramicContextState } from "../../context/ceramicContext";
+import { CeramicContextState, IsLoadingPassportState } from "../../context/ceramicContext";
 
 jest.mock("../../utils/onboard.ts");
 
@@ -134,7 +134,7 @@ describe("when app fails to load ceramic stream", () => {
       {
         ...mockCeramicContext,
         passport: undefined,
-        isLoadingPassport: undefined,
+        isLoadingPassport: IsLoadingPassportState.FailedToConnect,
       },
       <Router>
         <Dashboard />
@@ -160,7 +160,7 @@ describe("when app fails to load ceramic stream", () => {
       {
         ...mockCeramicContext,
         passport: undefined,
-        isLoadingPassport: undefined,
+        isLoadingPassport: IsLoadingPassportState.FailedToConnect,
       },
       <Router>
         <Dashboard />
@@ -178,7 +178,7 @@ describe("when app fails to load ceramic stream", () => {
       {
         ...mockCeramicContext,
         passport: undefined,
-        isLoadingPassport: undefined,
+        isLoadingPassport: IsLoadingPassportState.FailedToConnect,
       },
       <Router>
         <Dashboard />

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -9,7 +9,7 @@ import { VerifiableCredential } from "@gitcoin/passport-types";
 import { ProviderSpec } from "../config/providers";
 
 // --- Context
-import { CeramicContext } from "../context/ceramicContext";
+import { CeramicContext, IsLoadingPassportState } from "../context/ceramicContext";
 
 // --- Components
 import { JsonOutputModal } from "../components/JsonOutputModal";
@@ -82,7 +82,7 @@ export const Card = ({
           <p className="pleading-relaxed hidden md:inline-block">{providerSpec.description}</p>
         </div>
         {/* TODO: change this to passport===false and introduce an offline save state when passport===undefined */}
-        {!passport || isLoadingPassport ? (
+        {!passport || isLoadingPassport !== IsLoadingPassportState.Idle ? (
           <span className="flex w-full items-center justify-center border-t-2 p-3 text-gray-900">
             <span>
               <Spinner

--- a/app/context/ceramicContext.tsx
+++ b/app/context/ceramicContext.tsx
@@ -12,11 +12,17 @@ const IAM_ISSUER_DID = process.env.NEXT_PUBLIC_PASSPORT_IAM_ISSUER_DID || "";
 
 export interface CeramicContextState {
   passport: Passport | undefined | false;
-  isLoadingPassport: boolean | undefined;
+  isLoadingPassport: IsLoadingPassportState;
   allProvidersState: AllProvidersState;
   handleCreatePassport: () => Promise<void>;
   handleAddStamp: (stamp: Stamp) => Promise<void>;
   userDid: string | undefined;
+}
+
+export enum IsLoadingPassportState {
+  Idle,
+  Loading,
+  FailedToConnect,
 }
 
 export type AllProvidersState = {
@@ -63,7 +69,7 @@ const startingAllProvidersState: AllProvidersState = {
 
 const startingState: CeramicContextState = {
   passport: undefined,
-  isLoadingPassport: true,
+  isLoadingPassport: IsLoadingPassportState.Loading,
   allProvidersState: startingAllProvidersState,
   handleCreatePassport: async () => {},
   handleAddStamp: async () => {},
@@ -75,7 +81,7 @@ export const CeramicContext = createContext(startingState);
 export const CeramicContextProvider = ({ children }: { children: any }) => {
   const [allProvidersState, setAllProviderState] = useState(startingAllProvidersState);
   const [ceramicDatabase, setCeramicDatabase] = useState<CeramicDatabase | undefined>(undefined);
-  const [isLoadingPassport, setIsLoadingPassport] = useState<boolean | undefined>(true);
+  const [isLoadingPassport, setIsLoadingPassport] = useState<IsLoadingPassportState>(IsLoadingPassportState.Loading);
   const [passport, setPassport] = useState<Passport | undefined>(undefined);
   const [userDid, setUserDid] = useState<string | undefined>();
   const [viewerConnection] = useViewerConnection();
@@ -125,22 +131,21 @@ export const CeramicContextProvider = ({ children }: { children: any }) => {
   }, [ceramicDatabase]);
 
   const fetchPassport = async (database: CeramicDatabase): Promise<void> => {
-    setIsLoadingPassport(true);
+    setIsLoadingPassport(IsLoadingPassportState.Loading);
     // fetch, clean and set the new Passport state
     let passport = (await database.getPassport()) as Passport;
     if (passport) {
       passport = cleanPassport(passport, database) as Passport;
       hydrateAllProvidersState(passport);
       setPassport(passport);
-      setIsLoadingPassport(false);
+      setIsLoadingPassport(IsLoadingPassportState.Idle);
     } else if (passport === false) {
       handleCreatePassport();
     } else {
       // something is wrong with Ceramic...
       datadogRum.addError("Ceramic connection failed", { address });
       setPassport(passport);
-      // TODO use more expressive loading states
-      setIsLoadingPassport(undefined);
+      setIsLoadingPassport(IsLoadingPassportState.FailedToConnect);
     }
   };
 

--- a/app/pages/Dashboard.tsx
+++ b/app/pages/Dashboard.tsx
@@ -10,17 +10,17 @@ import { Footer } from "../components/Footer";
 
 // --Chakra UI Elements
 import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalOverlay,
   Spinner,
   useDisclosure,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalBody,
-  ModalFooter,
-  Button,
 } from "@chakra-ui/react";
 
-import { CeramicContext } from "../context/ceramicContext";
+import { CeramicContext, IsLoadingPassportState } from "../context/ceramicContext";
 import { UserContext } from "../context/userContext";
 
 import { useViewerConnection } from "@self.id/framework";
@@ -46,7 +46,7 @@ export default function Dashboard() {
 
   // Allow user to retry Ceramic connection if failed
   const retryConnection = () => {
-    if (isLoadingPassport == undefined && wallet) {
+    if (isLoadingPassport == IsLoadingPassportState.FailedToConnect && wallet) {
       // connect to ceramic (deliberately connect with a lowercase DID to match reader)
       ceramicConnect(new EthereumAuthProvider(wallet.provider, wallet.accounts[0].address.toLowerCase()));
       onRetryModalClose();
@@ -59,9 +59,8 @@ export default function Dashboard() {
     handleConnection();
   };
 
-  // isLoadingPassport undefined when there is an issue during fetchPassport attempt
   useEffect(() => {
-    if (isLoadingPassport == undefined) {
+    if (isLoadingPassport == IsLoadingPassportState.FailedToConnect) {
       onRetryModalOpen();
     }
   }, [isLoadingPassport]);
@@ -150,7 +149,7 @@ export default function Dashboard() {
           </div>
         )}
         <div className="w-full md:w-1/4">
-          {isLoadingPassport == undefined && retryModal}
+          {isLoadingPassport == IsLoadingPassportState.FailedToConnect && retryModal}
           {viewerConnection.status !== "connecting" &&
             (passport ? (
               <div>
@@ -183,8 +182,12 @@ export default function Dashboard() {
             ))}
         </div>
       </div>
-      {/* isLoadingPassport is undefined when there is a network error loading the passport */}
-      <CardList isLoading={isLoadingPassport || isLoadingPassport === undefined} />
+      <CardList
+        isLoading={
+          isLoadingPassport == IsLoadingPassportState.Loading ||
+          isLoadingPassport == IsLoadingPassportState.FailedToConnect
+        }
+      />
       {/* This footer contains dark colored text and dark images */}
       <Footer lightMode={false} />
     </>


### PR DESCRIPTION
chore(app): use enum for isLoadingPassport type instead of "boolean | undefined"

this should improve readability and prevent possible future bugs from boolean logic and the
falsiness of 'undefined'

[resolves #275]