### PR TITLE
Feat: GitHub org provider  - For Grant Hub and Round Manager

### DIFF
--- a/iam/__tests__/githubOrg.test.ts
+++ b/iam/__tests__/githubOrg.test.ts
@@ -1,0 +1,211 @@
+// ---- Test subject
+import { GithubOrgProvider } from "../src/providers/githubOrg";
+
+import { RequestPayload } from "@gitcoin/passport-types";
+
+// ----- Libs
+import axios from "axios";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const validGithubUserResponse = {
+  data: {
+    id: "18723656",
+    login: "my-login-handle",
+    type: "User",
+  },
+  status: 200,
+};
+
+const validGithubOrgResponse = {
+  data: [
+    {
+      login: "gitcoinco",
+    }
+  ],
+  status: 200,
+};
+
+const unexpectedGithubOrgResponse = {
+  data: [
+    {
+      login: "uniswap",
+    }
+  ],
+  status: 200,
+};
+
+const validCodeResponse = {
+  data: {
+    access_token: "762165719dhiqudgasyuqwt6235",
+  },
+  status: 200,
+};
+
+const code = "ABC123_ACCESSCODE";
+
+const org = "gitcoinco"
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAxios.post.mockImplementation(async (url, data, config) => {
+    return validCodeResponse;
+  });
+
+  mockedAxios.get.mockImplementation(async (url, config) => {
+    switch (url) {
+      case "https://api.github.com/user":
+        return validGithubUserResponse;
+      case "https://api.github.com/users/my-login-handle/orgs":
+        return validGithubOrgResponse
+      default:
+        return {
+          status: 404
+        }
+    }
+  });
+});
+
+describe("Attempt verification", function () {
+  it("handles valid verification attempt", async () => {
+    const clientId = process.env.GITHUB_CLIENT_ID;
+    const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+    const github = new GithubOrgProvider();
+    const githubPayload = await github.verify({
+      proofs: {
+        code,
+      },
+      org
+    } as unknown as RequestPayload);
+
+    // Check the request to get the token
+    expect(mockedAxios.post).toBeCalledWith(
+      `https://github.com/login/oauth/access_token?client_id=${clientId}&client_secret=${clientSecret}&code=${code}`,
+      {},
+      {
+        headers: { Accept: "application/json" },
+      }
+    );
+
+    // Check the request to get the user
+    expect(mockedAxios.get).toBeCalledWith("https://api.github.com/user", {
+      headers: { Authorization: "token 762165719dhiqudgasyuqwt6235" },
+    });
+
+    // Check the request to get the user's org
+    expect(mockedAxios.get).toBeCalledWith("https://api.github.com/users/my-login-handle/orgs", {
+      headers: { Authorization: "token 762165719dhiqudgasyuqwt6235" },
+    });
+
+    expect(githubPayload).toEqual({
+      valid: true,
+      record: {
+        org
+      },
+    });
+  });
+
+  it("should return invalid payload when unable to retrieve auth token", async () => {
+    mockedAxios.post.mockImplementation(async (url, data, config) => {
+      return {
+        status: 500,
+      };
+    });
+
+    const github = new GithubOrgProvider();
+
+    const githubPayload = await github.verify({
+      proofs: {
+        code,
+      },
+      org
+    } as unknown as RequestPayload);
+
+    expect(githubPayload).toMatchObject({ valid: false });
+  });
+
+  it("should return invalid payload when there is no id in verifyGithub response", async () => {
+    mockedAxios.get.mockImplementation(async (url, config) => {
+      return {
+        data: {
+          id: undefined,
+          login: "my-login-handle",
+          type: "User",
+        },
+        status: 200,
+      };
+    });
+
+    const github = new GithubOrgProvider();
+
+    const githubPayload = await github.verify({
+      proofs: {
+        code,
+      },
+      org
+    } as unknown as RequestPayload);
+
+    expect(githubPayload).toMatchObject({ valid: false });
+  });
+
+  it("should return invalid payload when a bad status code is returned by github user api", async () => {
+    mockedAxios.get.mockImplementation(async (url, config) => {
+      return {
+        status: 500,
+      };
+    });
+
+    const github = new GithubOrgProvider();
+
+    const githubPayload = await github.verify({
+      proofs: {
+        code,
+      },
+      org
+    } as unknown as RequestPayload);
+
+    expect(githubPayload).toMatchObject({ valid: false });
+  });
+
+  it("should return invalid payload when a bad status code is returned by github org api", async () => {
+    mockedAxios.get.mockImplementation(async (url, config) => {
+      if (url === "https://api.github.com/users/my-login-handle/orgs") {
+        return {
+          status: 500,
+        };
+      }
+    });
+
+    const github = new GithubOrgProvider();
+
+    const githubPayload = await github.verify({
+      proofs: {
+        code,
+      },
+      org
+    } as unknown as RequestPayload);
+
+    expect(githubPayload).toMatchObject({ valid: false });
+  });
+
+  it("should return invalid if provided org is not returned from github", async () => {
+    mockedAxios.get.mockImplementation(async (url, config) => {
+      if (url === "https://api.github.com/users/my-login-handle/orgs") {
+        return unexpectedGithubOrgResponse
+      }
+    });
+  
+    const github = new GithubOrgProvider();
+  
+    const githubPayload = await github.verify({
+      proofs: {
+        code,
+      },
+      org
+    } as unknown as RequestPayload);
+  
+    expect(githubPayload).toMatchObject({ valid: false });
+  });
+});

--- a/iam/__tests__/githubOrg.test.ts
+++ b/iam/__tests__/githubOrg.test.ts
@@ -10,10 +10,12 @@ jest.mock("axios");
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+const handle = "my-login-handle"
+
 const validGithubUserResponse = {
   data: {
     id: "18723656",
-    login: "my-login-handle",
+    login: handle,
     type: "User",
   },
   status: 200,
@@ -102,7 +104,8 @@ describe("Attempt verification", function () {
     expect(githubPayload).toEqual({
       valid: true,
       record: {
-        org
+        org,
+        handle
       },
     });
   });

--- a/iam/src/index.ts
+++ b/iam/src/index.ts
@@ -45,6 +45,8 @@ import { FacebookProvider } from "./providers/facebook";
 import { BrightIdProvider } from "./providers/brightid";
 import { GithubProvider } from "./providers/github";
 
+import { GithubOrgProvider } from "./providers/githubOrg";
+
 // Initiate providers - new Providers should be registered in this array...
 const providers = new Providers([
   // Example provider which verifies the payload when `payload.proofs.valid === "true"`
@@ -57,6 +59,7 @@ const providers = new Providers([
   new FacebookProvider(),
   new BrightIdProvider(),
   new GithubProvider(),
+  new GithubOrgProvider(),
 ]);
 
 // create the app and run on port

--- a/iam/src/providers/github.ts
+++ b/iam/src/providers/github.ts
@@ -48,7 +48,7 @@ export class GithubProvider implements Provider {
   }
 }
 
-const requestAccessToken = async (code: string): Promise<string> => {
+export const requestAccessToken = async (code: string): Promise<string> => {
   const clientId = process.env.GITHUB_CLIENT_ID;
   const clientSecret = process.env.GITHUB_CLIENT_SECRET;
 

--- a/iam/src/providers/githubOrg.ts
+++ b/iam/src/providers/githubOrg.ts
@@ -1,0 +1,114 @@
+// ----- Types
+import type { RequestPayload, VerifiedPayload } from "@gitcoin/passport-types";
+import type { Provider, ProviderOptions } from "../types";
+import { requestAccessToken } from "./github";
+import axios from "axios";
+
+export type GithubTokenResponse = {
+  access_token: string;
+};
+
+export type GithubFindMyUserResponse = {
+  id?: string;
+  login?: string;
+  type?: string;
+};
+
+type GHUserRequestPayload = RequestPayload & {
+  org?: string;
+};
+
+type GithubMyOrg = {
+  providedOrg: string;
+  matchingOrg: string;
+};
+
+// Export a Github Provider to carry out OAuth and return a record object
+export class GithubOrgProvider implements Provider {
+  // Give the provider a type so that we can select it with a payload
+  type = "GithubOrg";
+
+  // Options can be set here and/or via the constructor
+  _options = {};
+
+  // construct the provider instance with supplied options
+  constructor(options: ProviderOptions = {}) {
+    this._options = { ...this._options, ...options };
+  }
+
+  // verify that the Github user is a memeber of the provided organization
+  async verify(payload: GHUserRequestPayload): Promise<VerifiedPayload> {
+    let valid = false,
+      validPayload: GithubMyOrg;
+
+    try {
+      validPayload = await verifyGithub(payload.proofs.code, payload.org);
+    } catch (e) {
+      return { valid: false };
+    } finally {
+      valid = validPayload && validPayload.matchingOrg === validPayload.providedOrg;
+    }
+
+    return {
+      valid: valid,
+      record: {
+        org: validPayload.matchingOrg,
+      },
+    };
+  }
+}
+
+type GithubUserResponse = {
+  status: number;
+  data: {
+    login: string;
+  };
+};
+
+type Organization = {
+  login: string;
+};
+
+type GithubUserOrgResponse = {
+  status: number;
+  data: Organization[];
+};
+
+const verifyOrg = (data: Organization[], providedOrg: string): GithubMyOrg => {
+  const orgs = data;
+  const matchingOrgs = orgs.filter((org) => org.login === providedOrg);
+
+  if (matchingOrgs.length !== 1) {
+    throw `${providedOrg} not found in user profile`;
+  }
+  return {
+    providedOrg,
+    matchingOrg: matchingOrgs[0].login,
+  };
+};
+
+const verifyGithub = async (code: string, providedOrg: string): Promise<GithubMyOrg> => {
+  // retrieve user's auth bearer token to authenticate client
+  const accessToken = await requestAccessToken(code);
+
+  // Now that we have an access token fetch the user details
+  const userRequest: GithubUserResponse = await axios.get("https://api.github.com/user", {
+    headers: { Authorization: `token ${accessToken}` },
+  });
+  if (userRequest.status != 200) {
+    throw `Get user request returned status code ${userRequest.status} instead of the expected 200`;
+  }
+
+  const userName = userRequest.data.login;
+
+  const userOrgRequest: GithubUserOrgResponse = await axios.get(`https://api.github.com/users/${userName}/orgs`, {
+    headers: { Authorization: `token ${accessToken}` },
+  });
+
+  if (userOrgRequest.status != 200) {
+    throw `Get user org request returned status code ${userOrgRequest.status} instead of the expected 200`;
+  }
+
+  const validOrg = verifyOrg(userOrgRequest.data, providedOrg);
+  return validOrg;
+};


### PR DESCRIPTION
Context from open discussion
```
We could add the issuance of a new class of Twitter stamp to the Passport IAM server that we don't highlight in the passport ui. In fact, this wouldn't be a stamp at all, it would just be the process for issuing a new VC. 

All the IAM server is concerned with is validating that the provided oauth association is valid and it will construct and sign a VC with those details in response. Its already abstracted away from the frontend service and doesn't communicate at all with anyone other than the user and the providers/chain.

So, if we are going to go down the road of creating a service to handle this, we already have one ready in Passport - we just need to add the issuance of a plaintext Twitter stamp.

I would also suggest storing the VC on IPFS and storing the pointer onchain, that should cover everything and allow you to verify everything in-house (locally - once you've pulled in the data).
```
These changes would add a new provider that issues a credential asserting that a github account is a member of the passed github organization.

This credential would be stored on ipfs with an on chain pointer. The assumption is that it could then be verified from within the round manager using the passport-sdk