### PR TITLE
feat(platforms, app): refactor logic around initiating issueing a cre…

### DIFF
--- a/app/components/GenericOauthPlatform.tsx
+++ b/app/components/GenericOauthPlatform.tsx
@@ -27,14 +27,14 @@ import { UserContext } from "../context/userContext";
 
 // --- Types
 import { PlatformGroupSpec } from "@gitcoin/passport-platforms/dist/commonjs/src/types";
-import { Platform } from "@gitcoin/passport-platforms/dist/commonjs/src/types";
+import { Platform, CallbackParameters, Proofs } from "@gitcoin/passport-platforms/dist/commonjs/src/types";
 import { getPlatformSpec, PROVIDER_ID } from "@gitcoin/passport-platforms/dist/commonjs/src/platforms-config";
 
 type PlatformProps = {
   // platformId: string;
   platformgroupspec: PlatformGroupSpec[];
   platform: Platform;
-  accessTokenRequest?(callback: (proof: { [k: string]: string | boolean }) => void): void;
+  accessTokenRequest?(callback: (params: CallbackParameters) => void): void;
 };
 
 function generateUID(length: number) {
@@ -90,7 +90,7 @@ export const GenericOauthPlatform = ({
   // --- Chakra functions
   const toast = useToast();
 
-  async function fetchCredential(proofs: { [k: string]: string }): Promise<void> {
+  async function fetchCredential(proofs: Proofs): Promise<void> {
     setLoading(true);
     // fetch VCs for only the selectedProviders
     const vcs = await fetchVerifiableCredential(
@@ -155,11 +155,11 @@ export const GenericOauthPlatform = ({
   async function initiateFetchCredential() {
     if (accessTokenRequest) {
       try {
-        accessTokenRequest((proof: any) => {
-          if (!proof.authenticated) {
-            setLoading(false);
+        accessTokenRequest((loginAttempt: CallbackParameters) => {
+          if (loginAttempt.authenticated && loginAttempt.proofs) {
+            fetchCredential(loginAttempt.proofs);
           } else {
-            fetchCredential(proof);
+            setLoading(false);
           }
         });
       } catch (e) {

--- a/platforms/src/Facebook/App-Bindings.ts
+++ b/platforms/src/Facebook/App-Bindings.ts
@@ -1,23 +1,23 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { Platform, Proof } from "../types";
+import { Platform, CallbackParameters } from "../types";
 export class FacebookPlatform implements Platform {
   path: string;
   platformId = "Facebook";
 
-  getAccessToken(callback: (proof: Proof) => void): void {
+  getAccessToken(callback: (params: CallbackParameters) => void): void {
     // TODO: Shouldn't need all of these ignores, should be just this //@ts-ignore assuming FB.init was already called; see facebookSdkScript in pages/index.tsx once tsconfigs are normalized
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore assuming FB.init was already called; see facebookSdkScript in app/pages/_app.tsx
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     FB.login(function (response) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (!response.authenticated) {
-        callback({ authenticated: false });
-      } else {
+      if (response.authenticated) {
         callback({
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          accessToken: response.accessToken,
+          authenticated: true,
+          proofs: { accessToken: response.accessToken },
         });
+      } else {
+        callback({ authenticated: false });
       }
     });
     return;

--- a/platforms/src/types.ts
+++ b/platforms/src/types.ts
@@ -33,13 +33,18 @@ export interface Provider {
 // Use unknown
 export type ProviderOptions = Record<string, unknown>;
 
-export type Proof = { [k: string]: string | boolean };
+export type Proofs = { [k: string]: string };
+
+export type CallbackParameters = {
+  proofs?: Proofs;
+  authenticated: boolean;
+};
 
 export interface Platform {
   platformId: string;
   path?: string;
   getOAuthUrl?(state: string): Promise<string>;
-  getAccessToken?(callback: (proof: Proof) => void): void;
+  getAccessToken?(callback: (params: CallbackParameters) => void): void;
 }
 
 export type PlatformOptions = Record<string, unknown>;


### PR DESCRIPTION
Theres a bug in the callback logic for the callback of accessTokenRequest, this should resolve it and initiate a verification of the Facebook stamp