### PR TITLE
add-ENS-stamp-banner

### DIFF
--- a/platforms/src/Ens/App-Bindings.ts
+++ b/platforms/src/Ens/App-Bindings.ts
@@ -6,8 +6,9 @@ export class EnsPlatform extends Platform {
   path = "Ens";
   clientId: string = null;
   redirectUri: string = null;
-  
-  bannerContent = "The ENS stamp only recognizes ENS domains if they are set to your account as primary ENS (or reverse record).";
+
+  bannerContent =
+    "The ENS stamp only recognizes ENS domains if they are set to your account as primary ENS (or reverse record).";
 
   async getProviderPayload(appContext: AppContext): Promise<ProviderPayload> {
     const result = await Promise.resolve({});

--- a/platforms/src/Ens/App-Bindings.ts
+++ b/platforms/src/Ens/App-Bindings.ts
@@ -6,6 +6,8 @@ export class EnsPlatform extends Platform {
   path = "Ens";
   clientId: string = null;
   redirectUri: string = null;
+  
+  bannerContent = "The ENS stamp only recognizes ENS domains if they are set to your account as primary ENS (or reverse record).";
 
   async getProviderPayload(appContext: AppContext): Promise<ProviderPayload> {
     const result = await Promise.resolve({});


### PR DESCRIPTION
Support flagged that Passport holders are unaware they need to set up reverse records to verify ENS. Here's a PR to add a banner to the ENS stamp to address that.