### PR TITLE
Add mainnet info banner for gnosis nft stamps

### DIFF
--- a/platforms/src/GnosisSafe/App-Bindings.ts
+++ b/platforms/src/GnosisSafe/App-Bindings.ts
@@ -5,8 +5,9 @@ export class GnosisSafePlatform extends Platform {
   platformId = "GnosisSafe";
   path = "GnosisSafe";
 
-  bannerContent = "Currently, we only recognize Gnosis Safes on the Ethereum main network. So you can't get that stamp through your Gnosis Safes on other networks.";
-  
+  bannerContent =
+    "Currently, we only recognize Gnosis Safes on the Ethereum main network. So you can't get that stamp through your Gnosis Safes on other networks.";
+
   async getProviderPayload(appContext: AppContext): Promise<ProviderPayload> {
     const result = await Promise.resolve({});
     return result;

--- a/platforms/src/NFT/App-Bindings.ts
+++ b/platforms/src/NFT/App-Bindings.ts
@@ -5,7 +5,8 @@ export class NFTPlatform extends Platform {
   platformId = "NFT";
   path = "NFT";
 
-  bannerContent = "Currently, we only recognize NFTs on the Ethereum main network. So you can't get that stamp through your NFTs on other networks.";
+  bannerContent =
+    "Currently, we only recognize NFTs on the Ethereum main network. So you can't get that stamp through your NFTs on other networks.";
 
   async getProviderPayload(appContext: AppContext): Promise<ProviderPayload> {
     const result = await Promise.resolve({});


### PR DESCRIPTION
Adding banners to NFT and Gnosis Safe stamps, highlighting that we only recognize these on Eth mainnet respectively.