### PR TITLE
feat: link passport logo to landing

### DIFF
--- a/app/__test-fixtures__/contextTestHelpers.tsx
+++ b/app/__test-fixtures__/contextTestHelpers.tsx
@@ -10,7 +10,8 @@ import { PlatformProps } from "../components/GenericPlatform";
 export const makeTestUserContext = (initialState?: Partial<UserContextState>): UserContextState => {
   return {
     loggedIn: true,
-    handleConnection: jest.fn(),
+    toggleConnection: jest.fn(),
+    handleDisconnection: jest.fn(),
     address: mockAddress,
     wallet: mockWallet,
     signer: undefined,

--- a/app/__tests__/components/GenericPlatform.test.tsx
+++ b/app/__tests__/components/GenericPlatform.test.tsx
@@ -32,12 +32,12 @@ jest.mock("../../utils/helpers.tsx", () => ({
   }),
 }));
 
-const mockHandleConnection = jest.fn();
+const mockToggleConnection = jest.fn();
 const mockCreatePassport = jest.fn();
 const mockHandleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockSigner = mock(JsonRpcSigner) as unknown as JsonRpcSigner;
 const mockUserContext: UserContextState = makeTestUserContext({
-  handleConnection: mockHandleConnection,
+  toggleConnection: mockToggleConnection,
   address: mockAddress,
   signer: mockSigner,
 });

--- a/app/__tests__/components/ProviderCards/BrightidCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/BrightidCard.test.tsx
@@ -22,12 +22,12 @@ jest.mock("@gitcoin/passport-identity/dist/commonjs/src/credentials", () => ({
 }));
 jest.mock("../../../utils/onboard.ts");
 
-const mockHandleConnection = jest.fn();
+const mockToggleConnection = jest.fn();
 const mockCreatePassport = jest.fn();
 const mockHandleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockSigner = mock(JsonRpcSigner) as unknown as JsonRpcSigner;
 const mockUserContext: UserContextState = makeTestUserContext({
-  handleConnection: mockHandleConnection,
+  toggleConnection: mockToggleConnection,
   address: mockAddress,
   signer: mockSigner,
 });

--- a/app/__tests__/components/ProviderCards/EnsCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/EnsCard.test.tsx
@@ -22,12 +22,12 @@ jest.mock("@gitcoin/passport-identity/dist/commonjs/src/credentials", () => ({
 }));
 jest.mock("../../../utils/onboard.ts");
 
-const mockHandleConnection = jest.fn();
+const mockToggleConnection = jest.fn();
 const mockCreatePassport = jest.fn();
 const mockHandleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockSigner = mock(JsonRpcSigner) as unknown as JsonRpcSigner;
 const mockUserContext: UserContextState = makeTestUserContext({
-  handleConnection: mockHandleConnection,
+  toggleConnection: mockToggleConnection,
   address: mockAddress,
   signer: mockSigner,
 });

--- a/app/__tests__/components/ProviderCards/GitPOAPCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/GitPOAPCard.test.tsx
@@ -22,13 +22,13 @@ jest.mock("@gitcoin/passport-identity/dist/commonjs/src/credentials", () => ({
 }));
 jest.mock("../../../utils/onboard.ts");
 
-const mockHandleConnection = jest.fn();
+const mockToggleConnection = jest.fn();
 const mockCreatePassport = jest.fn();
 const mockHandleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockSigner = mock(JsonRpcSigner) as unknown as JsonRpcSigner;
 
 const mockUserContext: UserContextState = makeTestUserContext({
-  handleConnection: mockHandleConnection,
+  toggleConnection: mockToggleConnection,
   address: mockAddress,
   signer: mockSigner,
 });

--- a/app/__tests__/components/ProviderCards/PoapCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/PoapCard.test.tsx
@@ -22,13 +22,13 @@ jest.mock("@gitcoin/passport-identity/dist/commonjs/src/credentials", () => ({
 }));
 jest.mock("../../../utils/onboard.ts");
 
-const mockHandleConnection = jest.fn();
+const mockToggleConnection = jest.fn();
 const mockCreatePassport = jest.fn();
 const mockHandleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockSigner = mock(JsonRpcSigner) as unknown as JsonRpcSigner;
 
 const mockUserContext: UserContextState = makeTestUserContext({
-  handleConnection: mockHandleConnection,
+  toggleConnection: mockToggleConnection,
   address: mockAddress,
   signer: mockSigner,
 });

--- a/app/__tests__/components/ProviderCards/PohCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/PohCard.test.tsx
@@ -22,13 +22,13 @@ jest.mock("@gitcoin/passport-identity/dist/commonjs/src/credentials", () => ({
 }));
 jest.mock("../../../utils/onboard.ts");
 
-const mockHandleConnection = jest.fn();
+const mockToggleConnection = jest.fn();
 const mockCreatePassport = jest.fn();
 const mockHandleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockSigner = mock(JsonRpcSigner) as unknown as JsonRpcSigner;
 
 const mockUserContext: UserContextState = makeTestUserContext({
-  handleConnection: mockHandleConnection,
+  toggleConnection: mockToggleConnection,
   address: mockAddress,
   signer: mockSigner,
 });

--- a/app/__tests__/pages/Home.test.tsx
+++ b/app/__tests__/pages/Home.test.tsx
@@ -13,11 +13,11 @@ import { CeramicContextState } from "../../context/ceramicContext";
 
 jest.mock("../../utils/onboard.ts");
 
-const mockHandleConnection = jest.fn();
+const mockToggleConnection = jest.fn();
 
 const mockUserContext: UserContextState = makeTestUserContext({
   loggedIn: false,
-  handleConnection: mockHandleConnection,
+  toggleConnection: mockToggleConnection,
   address: undefined,
   wallet: null,
   signer: undefined,
@@ -37,7 +37,7 @@ test("renders connect wallet button", () => {
   expect(screen.getByTestId("connectWalletButton"));
 });
 
-test("clicking connect wallet button calls handleConnection", async () => {
+test("clicking connect wallet button calls toggleConnection", async () => {
   expect.assertions(1);
 
   renderWithContext(
@@ -52,6 +52,6 @@ test("clicking connect wallet button calls handleConnection", async () => {
   await userEvent.click(connectWalletButton);
 
   await waitFor(() => {
-    expect(mockHandleConnection).toBeCalledTimes(1);
+    expect(mockToggleConnection).toBeCalledTimes(1);
   });
 });

--- a/app/context/userContext.tsx
+++ b/app/context/userContext.tsx
@@ -22,7 +22,8 @@ import { AccountId } from "caip";
 
 export interface UserContextState {
   loggedIn: boolean;
-  handleConnection: () => void;
+  toggleConnection: () => void;
+  handleDisconnection: () => void;
   address: string | undefined;
   wallet: WalletState | null;
   signer: JsonRpcSigner | undefined;
@@ -31,7 +32,8 @@ export interface UserContextState {
 
 const startingState: UserContextState = {
   loggedIn: false,
-  handleConnection: () => {},
+  toggleConnection: () => {},
+  handleDisconnection: () => {},
   address: undefined,
   wallet: null,
   signer: undefined,
@@ -246,38 +248,46 @@ export const UserContextProvider = ({ children }: { children: any }) => {
   }, [viewerConnection.status]);
 
   // Toggle connect/disconnect
-  const handleConnection = (): void => {
+  const toggleConnection = (): void => {
     if (!address) {
-      connect()
-        .then(() => {
-          datadogLogs.logger.info("Connected to Wallet");
-          setLoggedIn(true);
-        })
-        .catch((e) => {
-          datadogRum.addError(e);
-          throw e;
-        });
+      handleConnection();
     } else {
-      disconnect({
-        label: walletLabel || "",
-      })
-        .then(() => {
-          setLoggedIn(false);
-          ceramicDisconnect();
-          window.localStorage.setItem("connectedWallets", "[]");
-        })
-        .catch((e) => {
-          datadogRum.addError(e);
-          throw e;
-        });
+      handleDisconnection();
     }
+  };
+
+  const handleConnection = (): void => {
+    connect()
+      .then(() => {
+        datadogLogs.logger.info("Connected to Wallet");
+        setLoggedIn(true);
+      })
+      .catch((e) => {
+        datadogRum.addError(e);
+        throw e;
+      });
+  };
+
+  const handleDisconnection = (): void => {
+    disconnect({
+      label: walletLabel || "",
+    })
+      .then(() => {
+        setLoggedIn(false);
+        ceramicDisconnect();
+        window.localStorage.setItem("connectedWallets", "[]");
+      })
+      .catch((e) => {
+        datadogRum.addError(e);
+        throw e;
+      });
   };
 
   const stateMemo = useMemo(
     () => ({
       loggedIn,
       address,
-      handleConnection,
+      toggleConnection,
       wallet,
       signer,
       walletLabel,
@@ -290,7 +300,8 @@ export const UserContextProvider = ({ children }: { children: any }) => {
   const providerProps = {
     loggedIn,
     address,
-    handleConnection,
+    toggleConnection,
+    handleDisconnection,
     wallet,
     signer,
     walletLabel,

--- a/app/pages/Dashboard.tsx
+++ b/app/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 // --- React Methods
 import React, { useContext, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 // --Components
 import { CardList } from "../components/CardList";
@@ -27,7 +27,7 @@ import { useViewerConnection } from "@self.id/framework";
 import { EthereumAuthProvider } from "@self.id/web";
 
 export default function Dashboard() {
-  const { wallet, handleConnection } = useContext(UserContext);
+  const { wallet, toggleConnection, handleDisconnection } = useContext(UserContext);
   const { passport, isLoadingPassport } = useContext(CeramicContext);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -56,7 +56,7 @@ export default function Dashboard() {
   const closeModalAndDisconnect = () => {
     onRetryModalClose();
     // toggle wallet connect/disconnect
-    handleConnection();
+    toggleConnection();
   };
 
   useEffect(() => {
@@ -103,7 +103,9 @@ export default function Dashboard() {
         <div className="float-right mb-4 flex h-12 flex-row items-center font-medium text-gray-900 md:mb-0">
           <img src="/assets/gitcoinLogoDark.svg" alt="Gitcoin Logo" />
           <img className="ml-6 mr-6" src="/assets/logoLine.svg" alt="Logo Line" />
-          <img src="/assets/passportLogoBlack.svg" alt="pPassport Logo" />
+          <Link data-testid="passport-logo-link" to="/" onClick={handleDisconnection}>
+            <img src="/assets/passportLogoBlack.svg" alt="pPassport Logo" />
+          </Link>
         </div>
       </div>
 

--- a/app/pages/Home.tsx
+++ b/app/pages/Home.tsx
@@ -10,7 +10,7 @@ import { UserContext } from "../context/userContext";
 import { Footer } from "../components/Footer";
 
 export default function Home() {
-  const { handleConnection, address, walletLabel, wallet } = useContext(UserContext);
+  const { toggleConnection, address, walletLabel, wallet } = useContext(UserContext);
 
   const navigate = useNavigate();
 
@@ -46,7 +46,7 @@ export default function Home() {
               <button
                 data-testid="connectWalletButton"
                 className="rounded-sm rounded bg-purple-connectPurple px-10 py-2 text-white"
-                onClick={handleConnection}
+                onClick={toggleConnection}
               >
                 <p className="text-base">{address ? `Disconnect from ${walletLabel || ""}` : "Connect Wallet"}</p>
               </button>
@@ -68,7 +68,7 @@ export default function Home() {
           <button
             data-testid="connectWalletButtonMobile"
             className="w-full rounded-sm rounded bg-purple-connectPurple py-2 px-10 text-white md:invisible"
-            onClick={handleConnection}
+            onClick={toggleConnection}
           >
             <p className="text-base">{address ? `Disconnect from ${walletLabel || ""}` : "Connect Wallet"}</p>
           </button>


### PR DESCRIPTION
This PR adds a feature to disconnect the user's wallet and navigate to the landing page when the passport logo is clicked in the dashboard.


closes #841 