### PR TITLE
Use default CACAO expiry time

### DIFF
--- a/app/context/userContext.tsx
+++ b/app/context/userContext.tsx
@@ -161,7 +161,6 @@ export const UserContextProvider = ({ children }: { children: any }) => {
                 })
               );
               const session = await DIDSession.authorize(authMethod, {
-                expiresInSecs: 24 * 3600,
                 resources: ["ceramic://*"],
               });
               const newSessionStr = session.serialize();


### PR DESCRIPTION
The default CACAO expiry time is 1 week. Currently the passport app has the expiry time set to 1 day. If there is any trouble with the Ceramic anchor service used by the passport Ceramic node, 1 day is a pretty short period to recover from issues. Setting it to the default 1 week gives more room for recovering from potential errors.