### PR TITLE
feat: close remove stamp modal on failure

### DIFF
--- a/app/components/RemoveStampModal.tsx
+++ b/app/components/RemoveStampModal.tsx
@@ -43,22 +43,33 @@ export const RemoveStampModal = ({
   const toast = useToast();
 
   const handleStampRemoval = async () => {
-    setIsLoading(true);
-    await handleDeleteStamps(stampsToBeDeleted);
-    toast({
-      duration: 5000,
-      isClosable: true,
-      render: (result: any) => (
-        <DoneToastContent
-          title="Success!"
-          body="Stamp data has been removed."
-          icon="../assets/check-icon.svg"
-          result={result}
-        />
-      ),
-    });
-    setIsLoading(false);
-    onClose();
+    try {
+      setIsLoading(true);
+      await handleDeleteStamps(stampsToBeDeleted);
+      toast({
+        duration: 5000,
+        isClosable: true,
+        render: (result: any) => (
+          <DoneToastContent
+            title="Success!"
+            body="Stamp data has been removed."
+            icon="../assets/check-icon.svg"
+            result={result}
+          />
+        ),
+      });
+    } catch (error) {
+      toast({
+        duration: 5000,
+        status: "error",
+        title: "Error!",
+        description: "Something went wrong. Please try again.",
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+      onClose();
+    }
   };
 
   return (

--- a/app/context/ceramicContext.tsx
+++ b/app/context/ceramicContext.tsx
@@ -601,43 +601,68 @@ export const CeramicContextProvider = ({ children }: { children: any }) => {
   };
 
   const handleCreatePassport = async (): Promise<void> => {
-    if (ceramicDatabase) {
-      await ceramicDatabase.createPassport();
-      await fetchPassport(ceramicDatabase);
+    try {
+      if (ceramicDatabase) {
+        await ceramicDatabase.createPassport();
+        await fetchPassport(ceramicDatabase);
+      }
+    } catch (e) {
+      datadogLogs.logger.error("Error creating passport", { error: e });
+      throw e;
     }
   };
 
   const handleAddStamp = async (stamp: Stamp): Promise<void> => {
-    if (ceramicDatabase) {
-      await ceramicDatabase.addStamp(stamp);
-      await fetchPassport(ceramicDatabase, true);
+    try {
+      if (ceramicDatabase) {
+        await ceramicDatabase.addStamp(stamp);
+        await fetchPassport(ceramicDatabase, true);
+      }
+    } catch (e) {
+      datadogLogs.logger.error("Error add single stamp", { stamp, error: e });
+      throw e;
     }
   };
 
   const handleAddStamps = async (stamps: Stamp[]): Promise<void> => {
-    if (ceramicDatabase) {
-      await ceramicDatabase.addStamps(stamps);
-      await fetchPassport(ceramicDatabase, true);
+    try {
+      if (ceramicDatabase) {
+        await ceramicDatabase.addStamps(stamps);
+        await fetchPassport(ceramicDatabase, true);
+      }
+    } catch (e) {
+      datadogLogs.logger.error("Error adding multiple stamps", { stamps, error: e });
+      throw e;
     }
   };
 
   const handleDeleteStamps = async (providerIds: PROVIDER_ID[]): Promise<void> => {
-    if (ceramicDatabase) {
-      await ceramicDatabase.deleteStamps(providerIds);
-      await fetchPassport(ceramicDatabase, true);
+    try {
+      if (ceramicDatabase) {
+        await ceramicDatabase.deleteStamps(providerIds);
+        await fetchPassport(ceramicDatabase, true);
+      }
+    } catch (e) {
+      datadogLogs.logger.error("Error deleting multiple stamps", { providerIds, error: e });
+      throw e;
     }
   };
 
   const handleDeleteStamp = async (streamId: string): Promise<void> => {
-    if (ceramicDatabase) {
-      await ceramicDatabase.deleteStamp(streamId);
-      await new Promise((r) =>
-        // We need to delay the loading of stamps, in order for the deletion to be reflected in ceramic
-        setTimeout(async () => {
-          await fetchPassport(ceramicDatabase, true);
-          r(0);
-        }, 2000)
-      );
+    try {
+      if (ceramicDatabase) {
+        await ceramicDatabase.deleteStamp(streamId);
+        await new Promise((r) =>
+          // We need to delay the loading of stamps, in order for the deletion to be reflected in ceramic
+          setTimeout(async () => {
+            await fetchPassport(ceramicDatabase, true);
+            r(0);
+          }, 2000)
+        );
+      }
+    } catch (e) {
+      datadogLogs.logger.error("Error deleting single stamp", { streamId, error: e });
+      throw e;
     }
   };
 


### PR DESCRIPTION
This PR introduces the following

* close remove stamp modal on failure
* log stamp related errors in `ceramicContext.ts` to datadog

close #879 