### PR TITLE
fix(app): move callback listener up the tree so dependencies are not …

### DIFF
--- a/app/__tests__/pages/app.test.tsx
+++ b/app/__tests__/pages/app.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
-import Index from "../../pages/index";
+import App from "../../pages/_app";
+import { AppProps } from "next/app";
 
 jest.mock("../../utils/onboard.ts");
 jest.mock("@datadog/browser-rum");
@@ -39,7 +40,9 @@ describe("when index is provided queryParams matching twitters OAuth response", 
       value: mockCloseWindow,
     });
 
-    render(<Index />);
+    const appProps = {} as AppProps;
+
+    render(<App {...appProps} />);
 
     // expect message to be posted and window.close() to have been called
     expect(mockPostMessage).toBeCalledTimes(1);

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps, @next/next/no-img-element */
 // --- Methods
 import React from "react";
-import { BroadcastChannel } from "broadcast-channel";
 import { HashRouter as Router, Routes, Route } from "react-router-dom";
 
 // -- Next Methods
@@ -40,33 +39,6 @@ datadogLogs.init({
 });
 
 const App: NextPage = () => {
-  // pull any search params
-  const queryString = new URLSearchParams(window?.location?.search);
-  // Twitter oauth will attach code & state in oauth procedure
-  const queryError = queryString.get("error");
-  const queryCode = queryString.get("code");
-  const queryState = queryString.get("state");
-
-  // We expect for a queryState like" 'twitter-asdfgh', 'google-asdfghjk'
-  const providerPath = queryState?.split("-");
-  const provider = providerPath ? providerPath[0] : undefined;
-
-  // if Twitter oauth then submit message to other windows and close self
-  if ((queryError || queryCode) && queryState && provider) {
-    // shared message channel between windows (on the same domain)
-    const channel = new BroadcastChannel(`${provider}_oauth_channel`);
-
-    // only continue with the process if a code is returned
-    if (queryCode) {
-      channel.postMessage({ target: provider, data: { code: queryCode, state: queryState } });
-    }
-
-    // always close the redirected window
-    window.close();
-
-    return <div></div>;
-  }
-
   return (
     <div>
       <Router>


### PR DESCRIPTION
Fixes: #869 

From what I'm seeing the problematic bundles(5638 and 6988) are coming from the web3Onboard library when we are loading the temporary callback window. This pr should exit out before those bundles are called. 


<img width="522" alt="Screenshot 2023-04-05 at 5 08 01 PM" src="https://user-images.githubusercontent.com/6887938/230231248-e1aead32-0f34-4271-8b91-c0ff41400a2e.png">
<img width="453" alt="Screenshot 2023-04-05 at 5 08 46 PM" src="https://user-images.githubusercontent.com/6887938/230231335-ac0daea6-691d-414e-aa22-094ef98f2177.png">
