### PR TITLE
[civic] Disable OAuth for the Civic integration. Change the Civic CTA…

### DIFF
--- a/platforms/src/Civic/App-Bindings.ts
+++ b/platforms/src/Civic/App-Bindings.ts
@@ -1,20 +1,5 @@
-import { PlatformOptions } from "../types";
+import { AppContext, PlatformOptions, ProviderPayload } from "../types";
 import { Platform } from "../utils/platform";
-import { PROVIDER_ID } from "@gitcoin/passport-types";
-import { providers } from "./Providers-config";
-import { CivicPassProvider } from "./Providers/civic";
-import { CivicPassType } from "./Providers/types";
-
-const DEFAULT_SCOPE = "uniqueness";
-
-const mapProviderIDToScope = (provider: PROVIDER_ID): string | undefined => {
-  const foundProvider = providers.find((p) => p.type === provider);
-  const passType = (foundProvider as CivicPassProvider)?.passType;
-  if (passType) {
-    return CivicPassType[passType].toLowerCase();
-  }
-  return undefined;
-};
 
 export class CivicPlatform extends Platform {
   platformId = "Civic";
@@ -27,18 +12,18 @@ export class CivicPlatform extends Platform {
     this.redirectUri = options.redirectUri as string;
   }
 
-  getOAuthUrl(state?: string, providers?: PROVIDER_ID[]): Promise<string> {
-    const scope = providers?.length >= 1 ? mapProviderIDToScope(providers[0]) : DEFAULT_SCOPE;
-    return Promise.resolve(`https://getpass.civic.com?state=${state}&scope=${scope}&redirect_uri=${this.redirectUri}`);
+  async getProviderPayload(appContext: AppContext): Promise<ProviderPayload> {
+    const result = await Promise.resolve({});
+    return result;
   }
 
   banner = {
-    heading: "Choose a pass type and click Verify.",
+    heading: "Click on 'Get Civic Pass' to visit Civic and issue your passes.",
     content:
-      "For the best experience, switch to your desired network in your wallet first. Alternatively, visit the link below to get multiple passes.",
+      "Once you have one or more Civic Passes, select them above and click 'Verify'. Note: Polygon is recommended for the lowest gas cost.",
     cta: {
       label: "Get Civic Pass",
-      url: "https://getpass.civic.com",
+      url: "https://getpass.civic.com?scope=uniqueness,captcha,liveness&chain=polygon,arbitrum%20one,xdc,ethereum",
     },
   };
 }


### PR DESCRIPTION
- Disable OAuth for Civic integration. The CTA button will take the user directly to the getpass.civic.com page to request their pass.
- Update Civic banner copy.