### PR TITLE
Clarify stamp requires Community to stake to you

### DIFF
--- a/platforms/src/GtcStaking/Providers-config.ts
+++ b/platforms/src/GtcStaking/Providers-config.ts
@@ -19,7 +19,7 @@ export const PlatformDetails: PlatformSpec = {
 
 export const ProviderConfig: PlatformGroupSpec[] = [
   {
-    platformGroup: "Self GTC Staking",
+    platformGroup: "GTC Staking from Self",
     providers: [
       { title: "5 GTC (Bronze)", name: "SelfStakingBronze" },
       { title: "20 GTC (Silver)", name: "SelfStakingSilver" },
@@ -27,7 +27,7 @@ export const ProviderConfig: PlatformGroupSpec[] = [
     ],
   },
   {
-    platformGroup: "Community GTC Staking",
+    platformGroup: "GTC Staking from Community",
     providers: [
       { title: "5 GTC (Bronze)", name: "CommunityStakingBronze" },
       { title: "20 GTC (Silver)", name: "CommunityStakingSilver" },


### PR DESCRIPTION
This is a minor change to the wording within the Passport itself, that should help make it clear that the Community Staking stamp is earned when this address is staked on from another address.

My suggested wording is:
- GTC Staking from Self
(changed from: Self GTC Staking)
- GTC Staking from Community
(changed from: Community GTC Staking)