### PR TITLE
chore(app): re enable wallet connect

### DIFF
--- a/app/utils/onboard.ts
+++ b/app/utils/onboard.ts
@@ -1,6 +1,6 @@
 import { init } from "@web3-onboard/react";
 import injectedModule from "@web3-onboard/injected-wallets";
-// import walletConnectModule, { WalletConnectOptions } from "@web3-onboard/walletconnect";
+import walletConnectModule, { WalletConnectOptions } from "@web3-onboard/walletconnect";
 import { chains } from "./chains";
 
 // Injected wallet - shows all available injected wallets
@@ -8,21 +8,20 @@ import { chains } from "./chains";
 const injected = injectedModule();
 
 // web3Onboard modules
-// const walletConnectProjectId = (process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID as string) || "default-project-id";
-//
-// const walletConnectOptions: WalletConnectOptions = {
-//   projectId: walletConnectProjectId,
-// };
+const walletConnectProjectId = (process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID as string) || "default-project-id";
+
+const walletConnectOptions: WalletConnectOptions = {
+  projectId: walletConnectProjectId,
+};
 
 const onBoardExploreUrl =
   (process.env.NEXT_PUBLIC_WEB3_ONBOARD_EXPLORE_URL as string) || "https://passport.gitcoin.co/";
 
-// const walletConnect = walletConnectModule(walletConnectOptions);
+const walletConnect = walletConnectModule(walletConnectOptions);
 
 // Exports onboard-core instance (https://github.com/blocknative/web3-onboard)
 export const onboard = init({
-  // wallets: [injected, walletConnect],
-  wallets: [injected],
+  wallets: [injected, walletConnect],
   chains: chains.map(({ id, token, label, rpcUrl, icon }) => ({ id, token, label, rpcUrl, icon })),
   appMetadata: {
     name: "Passport",


### PR DESCRIPTION
Fixes: https://github.com/gitcoinco/passport/issues/1983



Safety update from walletconnect: https://twitter.com/WalletConnect/status/1735346187958432103

Update 📢

A fix has been deployed, and the genuine and verified Ledger Connect Kit version 1.1.8 is now propagating. 

We have worked closely with 
[@Ledger](https://twitter.com/Ledger)
 to disable a project ID thought to have been used to target users with phishing attacks, and have reported the suspected address.

Dapps using WalletConnect's services and products will not have been directly affected, but we continue to remind any that also use Ledger's Connect Kit or wagmi LedgerConnector to update their version of these immediately.

In our mission of connecting Web3, safety is critical, which is why we continue to focus on establishing robust security features like Verify API to support a stronger, safer web3 for all. We will continue to work with Ledger to better understand the attack and urge the community to always remain vigilant when engaging with apps in web3.