### PR TITLE
fix(app): pass individual provider ids instead of platform ids

### DIFF
--- a/app/__tests__/hooks/useOneClickVerification.test.tsx
+++ b/app/__tests__/hooks/useOneClickVerification.test.tsx
@@ -260,7 +260,16 @@ describe("useOneClickVerification", () => {
       expect(fetchVerifiableCredential).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          types: ["Ens", "NFT", "Lens", "GuildXYZ"],
+          types: [
+            "Ens",
+            "NFTScore#50",
+            "NFTScore#75",
+            "NFTScore#90",
+            "NFT",
+            "Lens",
+            "GuildAdmin",
+            "GuildPassportMember",
+          ],
         }),
         expect.any(Function)
       );

--- a/app/hooks/useOneClickVerification.tsx
+++ b/app/hooks/useOneClickVerification.tsx
@@ -41,7 +41,7 @@ export const useOneClickVerification = () => {
         // Nothing to do
         return;
       }
-      const platformTypes = possiblePlatforms.map((platform) => platform.platformProps.platform.platformId);
+
       setUserVerificationState({
         ...verificationState,
         loading: true,
@@ -56,7 +56,7 @@ export const useOneClickVerification = () => {
         iamUrl,
         {
           type: "EVMBulkVerify",
-          types: platformTypes,
+          types: validatedProviderIds,
           version: "0.0.0",
           address: address || "",
           proofs: {},


### PR DESCRIPTION
Fixes: When completing the one click onboard flow platform ids are currently being passed to the verify function, but it is expecting provider ids