### PR TITLE
Snyk upgrade 46bee50f1e5f0491859932cf8850356c

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -7,7 +7,7 @@
     "@1password/op-js": "^0.1.13",
     "@pulumi/aws": "^5.0.0",
     "@pulumi/cloudflare": "^5.26.0",
-    "@pulumi/github": "^6.7.0",
+    "@pulumi/github": "^6.7.2",
     "@pulumi/pulumi": "^3.0.0",
     "@pulumi/std": "^1.7.3",
     "infra-libs": "passportxyz/infra-libs#v1.3.0"

--- a/infra/yarn.lock
+++ b/infra/yarn.lock
@@ -500,10 +500,10 @@
   dependencies:
     "@pulumi/pulumi" "^3.136.0"
 
-"@pulumi/github@^6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/github/-/github-6.7.0.tgz#4921e0699b2909093c326fd48a9866b6f2f3b9bd"
-  integrity sha512-14LgAm6Q1CtIRoHE7E+17pr1a26ugR7IDzWoTgq1bvm8mmqUCIJs/8IbcQR+VwxY304fhN/n6YRqk/6MY9lsJw==
+"@pulumi/github@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@pulumi/github/-/github-6.7.2.tgz#1e1d5be3387c4ada986b9923a3aede9aebf9a633"
+  integrity sha512-dsaCLKQXqTVChE5gsowDoI7J3ZcN+WQ2zamFqHeYbSTJ2NJ06ENK+INkwbrUnEqtLA5t6lfOIu2F97Yz0+LsRQ==
   dependencies:
     "@pulumi/pulumi" "^3.142.0"
 


### PR DESCRIPTION
This pull request updates the dependencies in the `infra/package.json` file to use newer versions of two Pulumi packages.

Dependency updates:

* Updated `@pulumi/github` from version `^6.1.0` to `^6.7.2`.
* Updated `@pulumi/std` from version `^1.6.2` to `^1.7.3`.