### PR TITLE
fix: display network names instead of chain IDs in HUMN tooltip

### DIFF
--- a/app/components/MinimalHeader.tsx
+++ b/app/components/MinimalHeader.tsx
@@ -11,6 +11,7 @@ import TooltipOverChildren from "./TooltipOverChildren";
 import { applyMultiplier, beforeHumanPointsRelease } from "../utils/helpers";
 import { Icon } from "@chakra-ui/react";
 import { useCustomization } from "../hooks/useCustomization";
+import { getChainName } from "../utils/chains";
 
 type MinimalHeaderProps = {
   className?: string;
@@ -295,7 +296,7 @@ const PointsTooltip = ({ pointsData }: { pointsData: PointsData | undefined }) =
                   return (
                     <PointsTooltipItem
                       key={chainID}
-                      title={`Passport Minted (${chainID})`}
+                      title={`Passport Minted (${getChainName(chainID)})`}
                       text={`+${pointsData.breakdown?.[("PMT_" + chainID) as `PMT_${number}`] ?? 0}`}
                     />
                   );
@@ -310,7 +311,7 @@ const PointsTooltip = ({ pointsData }: { pointsData: PointsData | undefined }) =
                   return (
                     <PointsTooltipItem
                       key={chainID}
-                      title={`Human ID Minted (${chainID})`}
+                      title={`Human ID Minted (${getChainName(chainID)})`}
                       text={`+${pointsData.breakdown?.[("HIM_" + chainID) as `HIM_${number}`] ?? 0}`}
                     />
                   );

--- a/app/utils/chains.ts
+++ b/app/utils/chains.ts
@@ -365,3 +365,31 @@ export const networkMap = wagmiChains
   );
 
 export const chains: Chain[] = chainConfigs.map((config) => new Chain(config));
+
+const ALL_CHAIN_LABELS: Record<string, string> = {
+  // Mainnets
+  "0x1": "Ethereum Mainnet",
+  "0xa": "Optimism",
+  "0x89": "Polygon Mainnet",
+  "0xfa": "Fantom Mainnet",
+  "0x2105": "Base",
+  "0xe708": "Linea",
+  "0xa4b1": "Arbitrum One",
+  "0x144": "zkSync",
+  "0x82750": "Scroll",
+  "0x168": "Shape",
+  "0xa86a": "Avalanche",
+  "0x38": "BSC Mainnet",
+  "0xa4ec": "Celo Mainnet",
+  "0x64": "Gnosis Chain",
+  // Testnets
+  "0xaa36a7": "Sepolia",
+  "0x7a69": "Hardhat",
+  "0xaa37dc": "OP Sepolia Testnet",
+  "0x8274f": "Scroll Sepolia",
+};
+
+export const getChainName = (chainId: string): string => {
+  const hexChainId = chainId.startsWith("0x") ? chainId : `0x${parseInt(chainId, 10).toString(16)}`;
+  return ALL_CHAIN_LABELS[hexChainId] || chainId;
+};


### PR DESCRIPTION
Fixes: [#3689](https://github.com/passportxyz/passport/issues/3689)