### PR TITLE
feat(embed): filter out stamps with 0 displayWeight

### DIFF
--- a/embed/__tests__/metadataHandler.test.ts
+++ b/embed/__tests__/metadataHandler.test.ts
@@ -87,6 +87,35 @@ describe("GET /embed/stamps/metadata", () => {
     );
   });
 
+  it("should filter out platforms with 0 displayWeight", async () => {
+    // Mock the axios GET request with all weights set to 0
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        BinanceBABT: 0,
+        HolonymPhone: 0,
+        Google: 0,
+        // Add more providers with 0 weights
+        Discord: 0,
+        Github: 0,
+        Linkedin: 0,
+      },
+    });
+
+    const response = await request(app)
+      .get(`/embed/stamps/metadata?scorerId=${mockScorerId}`)
+      .set("Accept", "application/json")
+      .set("x-api-key", "test")
+      .expect(200)
+      .expect("Content-Type", /json/);
+
+    // With all weights set to 0, all platforms should be filtered out
+    // So we should have pages but no platforms
+    response.body.forEach((page: any) => {
+      expect(page.platforms).toHaveLength(0);
+    });
+  });
+
   describe("unexpected errors", () => {
     it("should handle errors from the embedWeightsUrl API correctly", async () => {
       mockedAxios.get.mockImplementationOnce(() => {


### PR DESCRIPTION
- Add filtering logic in metadata handler to exclude platforms with 0 weight
- Add comprehensive test coverage for the filtering functionality

Fixes: [3705](https://github.com/passportxyz/passport/issues/3705)