### PR TITLE
fix(app): fix verax dashboard binary score threshold comparison

### DIFF
--- a/app/components/VeraxPanel.tsx
+++ b/app/components/VeraxPanel.tsx
@@ -41,7 +41,7 @@ const chain = chains.find(({ id }) => id === LINEA_CHAIN_ID);
 export const VeraxPanel = ({ className, actionClassName }: { className: string; actionClassName?: string }) => {
   const [showSidebar, setShowSidebar] = useState(false);
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
-  const { score, scoreState } = useContext(ScorerContext);
+  const { rawScore, scoreState, passingScore } = useContext(ScorerContext);
   const { status: onChainStatus } = useOnChainStatus({ chain });
   const buttonText = getButtonMsg(onChainStatus);
 
@@ -85,7 +85,7 @@ export const VeraxPanel = ({ className, actionClassName }: { className: string; 
             actionClassName
           )}
           onClick={() => {
-            if (score < 100) {
+            if (!passingScore) {
               setConfirmModalOpen(true);
             } else {
               setShowSidebar(true);


### PR DESCRIPTION
- Replace hardcoded score < 100 comparison with passingScore boolean
- Fixes issue where users with passing binary score (1) were incorrectly compared against threshold of 100, always triggering low score warning
- Now correctly uses ScorerContext passingScore to determine if user passes
- Resolves binary score format compatibility issue introduced in recent changes

Fixes: Verax custom dashboard showing low score warning for all users