### PR TITLE
feat(app): add SOG and TCO human points actions

### DIFF
--- a/app/components/MinimalHeader.tsx
+++ b/app/components/MinimalHeader.tsx
@@ -323,6 +323,12 @@ const PointsTooltip = ({ pointsData }: { pointsData: PointsData | undefined }) =
             {pointsData.breakdown?.MM2 && (
               <PointsTooltipItem title="MetaMask OG" text={`+${pointsData.breakdown.MM2}`} />
             )}
+            {pointsData.breakdown?.SOG && (
+              <PointsTooltipItem title="Seasoned Passport OG" text={`+${pointsData.breakdown.SOG}`} />
+            )}
+            {pointsData.breakdown?.TCO && (
+              <PointsTooltipItem title="The Chosen One" text={`+${pointsData.breakdown.TCO}`} />
+            )}
           </ul>
         </>
       )}

--- a/app/context/scorerContext.tsx
+++ b/app/context/scorerContext.tsx
@@ -191,6 +191,8 @@ export type POINTS_BREAKDOWN_KEY =
   | "HIM"
   | "MTA"
   | "MM2"
+  | "SOG"
+  | "TCO"
   | `PMT_${number}`
   | `HIM_${number}`;
 


### PR DESCRIPTION
Add two new human points action types to the points breakdown system:
- SOG (Seasoned Passport OG)
- TCO (The Chosen One)

These new point types are now displayed in the HUMN points tooltip in the header when users earn them.

Changes:
- Add SOG and TCO to POINTS_BREAKDOWN_KEY type in scorerContext
- Add display logic for SOG and TCO in MinimalHeader points tooltip