### PR TITLE
feat(platforms): add supported Amazon countries list to ZKEmail platform

### DIFF
--- a/platforms/src/ZKEmail/Providers-config.ts
+++ b/platforms/src/ZKEmail/Providers-config.ts
@@ -68,6 +68,26 @@ export const PlatformDetails: PlatformSpec = {
         "For additional support, contact the team at support@zk.email",
       ],
     },
+    {
+      type: "list",
+      title: "Supported Amazon countries",
+      items: [
+        "🇨🇦 Canada",
+        "🇪🇲 Emirates",
+        "🇫🇷 France",
+        "🇩🇪 Germany",
+        "🇮🇳 India",
+        "🇮🇹 Italy",
+        "🇯🇵 Japan",
+        "🇲🇽 Mexico",
+        "🇳🇱 Netherlands",
+        "🇵🇱 Poland",
+        "🇪🇸 Spain",
+        "🇸🇪 Sweden",
+        "🇬🇧 UK",
+        "🇺🇸 USA",
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
## Summary

This PR adds a new 'Supported Amazon countries' section to the ZKEmail platform configuration to improve user experience by clearly showing which Amazon regions are supported for email verification.

## Changes

- Added new list section titled 'Supported Amazon countries' to the ZKEmail platform guide
- Included 14 supported countries with flag emojis, organized alphabetically:
  - 🇨🇦 Canada
  - 🇪🇲 Emirates  
  - 🇫🇷 France
  - 🇩🇪 Germany
  - 🇮🇳 India
  - 🇮🇹 Italy
  - 🇯🇵 Japan
  - 🇲🇽 Mexico
  - 🇳🇱 Netherlands
  - 🇵🇱 Poland
  - 🇪🇸 Spain
  - 🇸🇪 Sweden
  - 🇬🇧 UK
  - 🇺🇸 USA

## Testing

- ✅ All existing tests pass
- ✅ No linting errors
- ✅ Configuration follows existing patterns

## Impact

This change improves the user experience by providing clear visibility into which Amazon regions are supported for ZKEmail verification, helping users understand eligibility before attempting verification.

## Files Changed

-  - Added supported countries list to platform guide

fixes #3807