### PR TITLE
Feat/human id zk passport

### DIFF
--- a/.claude/knowledge/KNOWLEDGE_MAP_CLAUDE.md
+++ b/.claude/knowledge/KNOWLEDGE_MAP_CLAUDE.md
@@ -30,3 +30,4 @@
 - @gotchas/topnav_positioning_responsive.md - NavPopover responsive positioning issues across screen sizes
 - @gotchas/provider_external_calls.md - RPC timeout, URL encoding, no silent fallback, rejection tracking
 - @gotchas/usePlatforms_symmetric_guards.md - Guards must be symmetric across both useMemo blocks
+- @gotchas/humanid_offchain_attestation_expiry.md - Free ZK Passport 7-day off-chain attestation TTL clamps Government ID stamp expiry

--- a/.claude/knowledge/architecture/platform_system.md
+++ b/.claude/knowledge/architecture/platform_system.md
@@ -48,29 +48,53 @@ The platforms package has a unique architecture where both frontend and backend 
 - Both frontend and backend can share utility files (e.g., `utils.ts`, `constants.ts`)
 - Code runs in different runtime environments but shares type definitions
 
-## HumanID Dual-Path Architecture
+## HumanID Multi-Source Architecture
 
-BaseHumanIDPlatform supports two distinct verification paths:
+BaseHumanIDPlatform supports three verification source types. Platforms compose them:
 
-### 1. SBT Path (KYC, Phone, Biometrics)
-- **Method**: Uses `sbtFetcher` to retrieve on-chain SBTs
-- **Validation**: 
+### 1. SBT Sources (KYC, Phone, Biometrics, ZK Passport)
+- **Method**: `sbtFetcher` (single) or `sbtFetchers` (ordered list) — first valid SBT wins
+- **Validation**:
   - Checks publicValues array (minimum 5 elements)
   - Nullifier at index 3
   - Expiry validation using `>` (not `>=`) for consistency
-- **Providers**: Extend `BaseHumanIdProvider` for shared validation
+- **Providers**: Extend `BaseHumanIdProvider`. Override `sources()` to compose multiple SBT sources (e.g. Government ID accepts regular KYC SBT and ZK Passport SBT).
 
-### 2. Attestation Path (CleanHands)
+### 2. On-Chain Attestation Source (CleanHands)
 - **Method**: Uses `attestationFetcher` for Sign Protocol attestations
 - **Validation**: Checks `indexingValue` field exists and is non-empty
-- **Implementation**: Standalone provider (doesn't inherit `BaseHumanIdProvider`)
-- **Rationale**: Avoids forcing attestations into SBT pattern
+
+### 3. Off-Chain Attestation Source (Free ZK Passport)
+- **Method**: `hasValidOffChainAttestation` on the platform; the provider adds an
+  off-chain `CredentialSource` that fetches from id-server directly
+  (`getZkPassportFreeOffChainAttestation`).
+- **Validation**: Checks `expiresAt > now` and `payload.uniqueIdentifier` is non-empty
+- **Stamp expiry**: Sources may return `expiresInSeconds` to clamp the issued VC's
+  `expirationDate`. The free ZK Passport attestation has a 7-day TTL — see
+  `gotchas/humanid_offchain_attestation_expiry.md`.
+
+### Government ID — multi-source example
+`HumanIdKycProvider` (type `HolonymGovIdProvider`) accepts any of three Human ID
+issuance paths in this order: (1) regular KYC SBT, (2) paid ZK Passport SBT
+(record `sbtType: zk-passport-onchain`), (3) free ZK Passport off-chain
+attestation (record `sbtType: zk-passport-offchain`, `expiresInSeconds` clamped
+to attestation TTL).
+
+### Iframe option forwarding
+`BaseHumanIDPlatform` exposes `kycOptions` / `cleanHandsOptions` fields that are
+forwarded to `privateRequestSBT`, controlling which cards appear in the Human ID
+iframe chooser. `HumanIdKycPlatform` sets all three KYC flags (`regularKYC`,
+`paidZKPassport`, `freeZKPassport`). The `freeZKPassport` flag is stripped from
+the public `requestSBT` type but is accepted by the underlying
+`privateRequestSBT` — the local `ExtendedHumanIDProvider` cast in
+`HumanID/shared/types.ts` re-types it via `KycOptions` from
+`@holonym-foundation/human-id-interface-core`.
 
 ### Key Architectural Decisions
 - Shared validation logic in `utils.ts` to avoid duplication
 - Constants for credential types (no magic strings)
 - Record field in VerifiedPayload ignored when `valid=false`
-- Clean separation between SBT and attestation patterns
+- Sources are composable: each is `(address) => Promise<{valid, record, expiresInSeconds?} | {valid:false, error}>`
 
 ## isEVM Flag Architecture
 

--- a/.claude/knowledge/gotchas/humanid_offchain_attestation_expiry.md
+++ b/.claude/knowledge/gotchas/humanid_offchain_attestation_expiry.md
@@ -1,0 +1,52 @@
+# Free ZK Passport Off-Chain Attestation: 7-Day Expiry Clamp [2026-04-27]
+
+## Issue Description
+
+Human ID's free ZK Passport flow does **not** mint an SBT. It writes an off-chain
+attestation to id-server keyed by wallet address, valid for **7 days from issuance**.
+A user with only this attestation has no on-chain credential to fall back on, so the
+Government ID stamp's expiry must track the attestation, not Passport's default
+credential lifetime.
+
+## Mechanics
+
+- **Endpoint**: `GET https://id-server.holonym.io/off-chain-attestations/zk-passport?address=…`
+  (production-only; sandbox lives at `/sandbox/off-chain-attestations/...` and is not
+  wired into Passport).
+- **Response shape** (200 OK): `{ address, attestationType: "zk-passport", payload: { uniqueIdentifier }, issuedAt, expiresAt }` with ISO timestamps.
+- **404** = `NOT_FOUND` is the "no free attestation" signal — handled as `null`, not
+  an error. Other non-2xx responses throw.
+- id-server returns the **most recent** record regardless of expiry — callers must
+  check `expiresAt > now` themselves.
+
+## Stamp expiry plumbing
+
+Provider `verify()` returns `expiresInSeconds = Math.floor((expiresAt - now) / 1000)`
+on the off-chain branch. The IAM credential issuer
+(`identity/src/credentials.ts`) consumes this via
+`identity/src/verification.ts:237` and clamps the issued VC's `expirationDate`
+accordingly. SBT-based sources omit `expiresInSeconds` and get the default
+credential lifetime.
+
+## Source Order Implications
+
+Government ID provider tries SBT sources before the off-chain attestation. Any
+on-chain SBT (regular KYC or paid ZK Passport) short-circuits the off-chain
+check. This means a user who upgrades from free → paid ZK Passport gets a
+default-lifetime stamp on re-verification, not a 7-day-clamped one.
+
+## URL is hardcoded
+
+The id-server base URL (`https://id-server.holonym.io`) is hardcoded in
+`platforms/src/HumanID/shared/utils.ts`. There is no env-var override and no
+sandbox wiring. If we ever need staging or sandbox support we must reintroduce
+configuration there.
+
+## Related Files
+
+- `platforms/src/HumanID/shared/utils.ts` — `getZkPassportFreeOffChainAttestation`,
+  `validateOffChainAttestation`
+- `platforms/src/HumanIdKyc/Providers/humanIdKyc.ts` — `zkPassportOffChainSource`
+- `platforms/src/HumanIdKyc/App-Bindings.ts` — `hasValidOffChainAttestation`
+- `identity/src/credentials.ts`, `identity/src/verification.ts` —
+  `expiresInSeconds` → VC `expirationDate` plumbing

--- a/app/__mocks__/@holonym-foundation/human-id-sdk.js
+++ b/app/__mocks__/@holonym-foundation/human-id-sdk.js
@@ -8,8 +8,11 @@ export const mockPrivateRequestSBT = vi.fn();
 export const mockSetOptimismRpcUrl = vi.fn();
 export const mockGetPhoneSBTByAddress = vi.fn();
 export const mockGetKycSBTByAddress = vi.fn();
+export const mockGetZkPassportSBTByAddress = vi.fn();
+export const mockGetCleanHandsSPAttestationByAddress = vi.fn();
 export const mockUncheckedGetMinimalPhoneSBTByAddress = vi.fn();
 export const mockUncheckedGetMinimalKycSBTByAddress = vi.fn();
+export const mockUncheckedGetMinimalZkPassportSBTByAddress = vi.fn();
 
 // Mock Human ID provider instance
 const mockHumanIDProvider = {
@@ -43,16 +46,22 @@ mockGetPhoneSBTByAddress.mockResolvedValue({
   revoked: false,
 });
 mockGetKycSBTByAddress.mockResolvedValue(null);
+mockGetZkPassportSBTByAddress.mockResolvedValue(null);
+mockGetCleanHandsSPAttestationByAddress.mockResolvedValue(null);
 mockUncheckedGetMinimalPhoneSBTByAddress.mockResolvedValue([BigInt(Date.now()), true]); // [expiry, hasPhone]
 mockUncheckedGetMinimalKycSBTByAddress.mockResolvedValue(null);
+mockUncheckedGetMinimalZkPassportSBTByAddress.mockResolvedValue(null);
 
 // Export functions
 export const initHumanID = mockInitHumanID;
 export const setOptimismRpcUrl = mockSetOptimismRpcUrl;
 export const getPhoneSBTByAddress = mockGetPhoneSBTByAddress;
 export const getKycSBTByAddress = mockGetKycSBTByAddress;
+export const getZkPassportSBTByAddress = mockGetZkPassportSBTByAddress;
+export const getCleanHandsSPAttestationByAddress = mockGetCleanHandsSPAttestationByAddress;
 export const uncheckedGetMinimalPhoneSBTByAddress = mockUncheckedGetMinimalPhoneSBTByAddress;
 export const uncheckedGetMinimalKycSBTByAddress = mockUncheckedGetMinimalKycSBTByAddress;
+export const uncheckedGetMinimalZkPassportSBTByAddress = mockUncheckedGetMinimalZkPassportSBTByAddress;
 
 // Reset all mocks function for tests
 export const resetHumanIDMocks = () => {
@@ -63,6 +72,9 @@ export const resetHumanIDMocks = () => {
   mockSetOptimismRpcUrl.mockClear();
   mockGetPhoneSBTByAddress.mockClear();
   mockGetKycSBTByAddress.mockClear();
+  mockGetZkPassportSBTByAddress.mockClear();
+  mockGetCleanHandsSPAttestationByAddress.mockClear();
   mockUncheckedGetMinimalPhoneSBTByAddress.mockClear();
   mockUncheckedGetMinimalKycSBTByAddress.mockClear();
+  mockUncheckedGetMinimalZkPassportSBTByAddress.mockClear();
 };

--- a/platforms/package.json
+++ b/platforms/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@gitcoin/passport-types": "^1.0.0",
     "@guildxyz/sdk": "^2.5.0",
-    "@holonym-foundation/human-id-sdk": "^0.0.24",
+    "@holonym-foundation/human-id-interface-core": "^0.2.0",
+    "@holonym-foundation/human-id-sdk": "^0.3.0",
     "@spruceid/didkit-wasm": "^0.3.0-alpha0",
     "@zk-email/sdk": "2.0.11",
     "axios": "^1.7.9",

--- a/platforms/src/Biometrics/__tests__/biometrics.test.ts
+++ b/platforms/src/Biometrics/__tests__/biometrics.test.ts
@@ -152,8 +152,8 @@ describe("Attempt verification", function () {
       address: MOCK_ADDRESS,
     } as RequestPayload);
 
-    // When getExistingSbt throws, it returns undefined, which then fails validation
+    // SDK errors surface as the source error, prefixed with the credential type.
     expect(verifiedPayload.valid).toBe(false);
-    expect(verifiedPayload.errors).toEqual(["biometrics SBT not found"]);
+    expect(verifiedPayload.errors).toEqual(["biometrics Network error"]);
   });
 });

--- a/platforms/src/CleanHands/App-Bindings.tsx
+++ b/platforms/src/CleanHands/App-Bindings.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { BaseHumanIDPlatform } from "../HumanID/shared/BaseHumanIDPlatform.js";
 import { getCleanHandsSPAttestationByAddress } from "@holonym-foundation/human-id-sdk";
+import type { CleanHandsOptions } from "@holonym-foundation/human-id-interface-core";
 import { CLEAN_HANDS_CREDENTIAL_TYPE } from "./constants.js";
 import { Hyperlink } from "../utils/Hyperlink.js";
 
@@ -10,6 +11,14 @@ export class CleanHandsPlatform extends BaseHumanIDPlatform {
   path = "CleanHands";
   credentialType = CLEAN_HANDS_CREDENTIAL_TYPE;
   attestationFetcher = getCleanHandsSPAttestationByAddress; // Note: attestation, not SBT
+
+  // Show both the Onfido card and the ZK Passport card in the Human ID iframe.
+  // The ZK Passport branch issues to the same Sign Protocol schema, so the
+  // existing attestationFetcher covers both branches.
+  cleanHandsOptions: CleanHandsOptions = {
+    regularKYC: true,
+    zkPassport: true,
+  };
 
   banner = {
     content: (

--- a/platforms/src/HumanID/shared/BaseHumanIDPlatform.ts
+++ b/platforms/src/HumanID/shared/BaseHumanIDPlatform.ts
@@ -2,14 +2,25 @@ import React from "react";
 import { AppContext, PlatformOptions, ProviderPayload } from "../../types.js";
 import { Platform } from "../../utils/platform.js";
 import { CredentialType, setOptimismRpcUrl, HubV3SBT, SignProtocolAttestation } from "@holonym-foundation/human-id-sdk";
+import type { KycOptions, CleanHandsOptions } from "@holonym-foundation/human-id-interface-core";
 import { isAddress, validateSbt, validateAttestation, requestSBT } from "./utils.js";
 
 export abstract class BaseHumanIDPlatform extends Platform {
   abstract credentialType: CredentialType;
 
-  // Platforms must implement EITHER sbtFetcher OR attestationFetcher
+  // Platforms must implement EITHER sbtFetcher (or sbtFetchers) OR attestationFetcher
   sbtFetcher?: (address: string) => Promise<HubV3SBT | null>;
+  // Optional ordered list of SBT fetchers — first valid SBT wins. Used by platforms
+  // (e.g. Government ID) whose credential can come from multiple Human ID issuance paths.
+  sbtFetchers?: ReadonlyArray<(address: string) => Promise<HubV3SBT | null>>;
   attestationFetcher?: (address: string) => Promise<SignProtocolAttestation | null>;
+  // Optional check for an off-chain attestation (e.g. free ZK Passport, 7-day TTL).
+  // Returns truthy when a valid attestation exists for the address.
+  hasValidOffChainAttestation?: (address: string) => Promise<boolean>;
+
+  // Forwarded to privateRequestSBT so the iframe shows the matching card variants.
+  kycOptions?: KycOptions;
+  cleanHandsOptions?: CleanHandsOptions;
 
   constructor(options: PlatformOptions = {}) {
     super();
@@ -20,29 +31,41 @@ export abstract class BaseHumanIDPlatform extends Platform {
   async credentialChecker(address: string): Promise<boolean> {
     if (!isAddress(address)) return false;
 
-    // SBT path (KYC, Phone, Biometrics)
-    if (this.sbtFetcher) {
+    // SBT path — try every configured SBT fetcher (KYC, Phone, Biometrics, ZK Passport).
+    const sbtFetchers = this.sbtFetchers ?? (this.sbtFetcher ? [this.sbtFetcher] : []);
+    for (const fetcher of sbtFetchers) {
       try {
-        const sbt = await this.sbtFetcher(address);
-        const result = validateSbt(sbt);
-        return result.valid;
+        const sbt = await fetcher(address);
+        if (validateSbt(sbt).valid) return true;
       } catch {
-        return false;
+        // try next fetcher
       }
     }
 
-    // Attestation path (CleanHands)
+    // On-chain attestation path (CleanHands).
     if (this.attestationFetcher) {
       try {
         const attestation = await this.attestationFetcher(address);
-        const result = validateAttestation(attestation);
-        return result.valid;
+        if (validateAttestation(attestation).valid) return true;
       } catch {
-        return false;
+        // fall through
       }
     }
 
-    throw new Error("Platform must define either sbtFetcher or attestationFetcher");
+    // Off-chain attestation path (e.g. free ZK Passport, 7-day TTL).
+    if (this.hasValidOffChainAttestation) {
+      try {
+        if (await this.hasValidOffChainAttestation(address)) return true;
+      } catch {
+        // fall through
+      }
+    }
+
+    if (sbtFetchers.length === 0 && !this.attestationFetcher && !this.hasValidOffChainAttestation) {
+      throw new Error("Platform must define an SBT fetcher, an attestation fetcher, or an off-chain attestation check");
+    }
+
+    return false;
   }
 
   async hasExistingCredential(address: string): Promise<boolean> {
@@ -65,6 +88,8 @@ export abstract class BaseHumanIDPlatform extends Platform {
       signMessageAsync: appContext.signMessageAsync,
       sendTransactionAsync: appContext.sendTransactionAsync,
       switchChainAsync: appContext.switchChainAsync,
+      kycOptions: this.kycOptions,
+      cleanHandsOptions: this.cleanHandsOptions,
     });
   }
 }

--- a/platforms/src/HumanID/shared/BaseHumanIdProvider.ts
+++ b/platforms/src/HumanID/shared/BaseHumanIdProvider.ts
@@ -1,41 +1,71 @@
 import type { RequestPayload, VerifiedPayload } from "@gitcoin/passport-types";
-import {
-  Provider,
-  ProviderOptions,
-  ProviderExternalVerificationError,
-  ProviderInternalVerificationError,
-} from "../../types.js";
-import { setOptimismRpcUrl } from "@holonym-foundation/human-id-sdk";
+import { Provider, ProviderOptions, ProviderInternalVerificationError } from "../../types.js";
+import { setOptimismRpcUrl, HubV3SBT } from "@holonym-foundation/human-id-sdk";
 import { validateSbt, isAddress } from "./utils.js";
+
+/**
+ * A credential source produces a per-source verification result. The provider's
+ * verify() iterates sources in order and returns the first valid result, otherwise
+ * an aggregated failure.
+ *
+ * `expiresInSeconds` (when set) flows through to the issued VC's `expirationDate`
+ * via identity/src/verification.ts and identity/src/credentials.ts. SBT-based
+ * sources omit it (they get the default credential expiry); off-chain attestation
+ * sources set it to the remaining attestation lifetime.
+ */
+export type CredentialSourceResult =
+  | { valid: true; record: Record<string, string>; expiresInSeconds?: number }
+  | { valid: false; error: string };
+
+export type CredentialSource = (address: string) => Promise<CredentialSourceResult>;
+
+/** Build a CredentialSource from an SBT fetcher. Errors and missing SBTs are reported as failures. */
+export function sbtSource(
+  fetcher: (address: string) => Promise<HubV3SBT | null>,
+  recordExtras: Record<string, string> = {}
+): CredentialSource {
+  return async (address: string): Promise<CredentialSourceResult> => {
+    let sbt: HubV3SBT | null;
+    try {
+      sbt = await fetcher(address);
+    } catch (e) {
+      // SDK throws when the SBT is not found; treat as a missing credential, not a hard error.
+      return { valid: false, error: e instanceof Error ? e.message : "SBT lookup failed" };
+    }
+
+    const result = validateSbt(sbt);
+    if (!result.valid) return { valid: false, error: (result as any).error };
+
+    return {
+      valid: true,
+      record: {
+        // Public Values: [expiry, recipientAddress, actionId, nullifier, issuerAddress]
+        nullifier: sbt?.publicValues?.[3]?.toString() ?? "",
+        ...recordExtras,
+      },
+    };
+  };
+}
 
 export abstract class BaseHumanIdProvider implements Provider {
   abstract type: string;
-  abstract sbtFetcher: (
-    address: string
-  ) => Promise<{ expiry: bigint; publicValues: bigint[]; revoked: boolean } | null>;
   abstract credentialType: string;
+
+  // Single-source subclasses (Phone, Biometrics) define `sbtFetcher`. Multi-source
+  // subclasses (Government ID) override `sources()` to return an ordered list.
+  sbtFetcher?: (address: string) => Promise<HubV3SBT | null>;
 
   constructor(_options: ProviderOptions = {}) {}
 
-  async getExistingSbt(address: string): Promise<{ expiry: bigint; publicValues: bigint[]; revoked: boolean } | null> {
-    try {
-      return await this.sbtFetcher(address);
-    } catch {
-      /* Throws when SBT not found */
+  /**
+   * Override to provide a custom ordered list of credential sources. Default
+   * implementation wraps the single `sbtFetcher` for backward compatibility.
+   */
+  protected sources(): CredentialSource[] {
+    if (!this.sbtFetcher) {
+      throw new ProviderInternalVerificationError("Provider must define sbtFetcher or override sources()");
     }
-  }
-
-  _validateSbt(sbt: any) {
-    const result = validateSbt(sbt);
-
-    if (!result.valid) {
-      return {
-        valid: false,
-        errors: [`${this.credentialType} ${(result as any).error}`],
-      };
-    }
-
-    return { valid: true };
+    return [sbtSource(this.sbtFetcher)];
   }
 
   async verify(payload: RequestPayload): Promise<VerifiedPayload> {
@@ -43,25 +73,31 @@ export abstract class BaseHumanIdProvider implements Provider {
     if (!rpcUrl) {
       throw new ProviderInternalVerificationError("Optimism RPC URL not configured");
     }
-
     setOptimismRpcUrl(rpcUrl);
 
-    // Validate address format
     if (!isAddress(payload.address)) {
       throw new ProviderInternalVerificationError("Invalid address format");
     }
 
-    const sbt = await this.getExistingSbt(payload.address);
-
-    const { valid, errors } = this._validateSbt(sbt);
+    const sources = this.sources();
+    const errors: string[] = [];
+    for (const source of sources) {
+      const result = await source(payload.address);
+      if (result.valid) {
+        return {
+          valid: true,
+          record: result.record,
+          expiresInSeconds: result.expiresInSeconds,
+        };
+      }
+      // After the early return above, TS narrowing keeps `result.valid === false` here.
+      errors.push((result as { valid: false; error: string }).error);
+    }
 
     return {
-      valid,
-      errors,
-      record: {
-        // Public Values: [expiry, recipientAddress, actionId, nullifier, issuerAddress]
-        nullifier: sbt?.publicValues?.[3]?.toString(),
-      },
+      valid: false,
+      errors: [`${this.credentialType} ${errors.join("; ")}`],
+      record: {},
     };
   }
 }

--- a/platforms/src/HumanID/shared/__tests__/BaseHumanIDPlatform.test.ts
+++ b/platforms/src/HumanID/shared/__tests__/BaseHumanIDPlatform.test.ts
@@ -192,7 +192,7 @@ describe("BaseHumanIDPlatform", () => {
         const platform = new InvalidPlatform({} as PlatformOptions);
 
         await expect(platform.credentialChecker("0x1234567890123456789012345678901234567890")).rejects.toThrow(
-          "Platform must define either sbtFetcher or attestationFetcher"
+          "Platform must define an SBT fetcher, an attestation fetcher, or an off-chain attestation check"
         );
       });
     });

--- a/platforms/src/HumanID/shared/__tests__/utils.test.ts
+++ b/platforms/src/HumanID/shared/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { validateSbt, validateAttestation, isHexString, isAddress } from "../utils.js";
+import { validateSbt, validateAttestation, isHexString, isAddress, validateOffChainAttestation } from "../utils.js";
 
 describe("isHexString", () => {
   it("should return true for strings starting with 0x", () => {
@@ -174,5 +174,65 @@ describe("validateAttestation", () => {
       expect(result.valid).toBe(false);
       expect((result as any).error).toBe("Invalid attestation - missing indexingValue");
     });
+  });
+});
+
+describe("validateOffChainAttestation", () => {
+  const futureIso = (msFromNow: number) => new Date(Date.now() + msFromNow).toISOString();
+
+  it("returns valid with parsed expiresAt for an unexpired attestation", () => {
+    const result = validateOffChainAttestation({
+      address: "0xabc",
+      attestationType: "zk-passport",
+      payload: { uniqueIdentifier: "uid-1" },
+      issuedAt: new Date(Date.now() - 60_000).toISOString(),
+      expiresAt: futureIso(60_000),
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    }
+  });
+
+  it("returns invalid for null", () => {
+    const result = validateOffChainAttestation(null);
+    expect(result.valid).toBe(false);
+    expect((result as any).error).toMatch(/not found/);
+  });
+
+  it("returns invalid when uniqueIdentifier is empty", () => {
+    const result = validateOffChainAttestation({
+      address: "0xabc",
+      attestationType: "zk-passport",
+      payload: { uniqueIdentifier: "" },
+      issuedAt: new Date().toISOString(),
+      expiresAt: futureIso(60_000),
+    });
+    expect(result.valid).toBe(false);
+    expect((result as any).error).toMatch(/uniqueIdentifier/);
+  });
+
+  it("returns invalid when expiresAt is in the past", () => {
+    const result = validateOffChainAttestation({
+      address: "0xabc",
+      attestationType: "zk-passport",
+      payload: { uniqueIdentifier: "uid-1" },
+      issuedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    expect(result.valid).toBe(false);
+    expect((result as any).error).toMatch(/expired/);
+  });
+
+  it("returns invalid when expiresAt is unparseable", () => {
+    const result = validateOffChainAttestation({
+      address: "0xabc",
+      attestationType: "zk-passport",
+      payload: { uniqueIdentifier: "uid-1" },
+      issuedAt: new Date().toISOString(),
+      expiresAt: "not-a-date",
+    });
+    expect(result.valid).toBe(false);
+    expect((result as any).error).toMatch(/invalid expiresAt/);
   });
 });

--- a/platforms/src/HumanID/shared/types.ts
+++ b/platforms/src/HumanID/shared/types.ts
@@ -1,5 +1,10 @@
 import { CredentialType } from "@holonym-foundation/human-id-sdk";
-import type { RequestSBTExtraParams } from "@holonym-foundation/human-id-interface-core";
+import type {
+  RequestSBTExtraParams,
+  KycOptions,
+  CleanHandsOptions,
+  PaymentConfig,
+} from "@holonym-foundation/human-id-interface-core";
 
 type RequestSBTResponse = null | {
   sbt: {
@@ -17,8 +22,17 @@ interface HumanIDProviderInterface {
   requestSBT(type: CredentialType, args: RequestSBTExtraParams): Promise<unknown>;
 }
 
+// privateRequestSBT accepts the full unrestricted KycOptions (including freeZKPassport),
+// unlike the public requestSBT which strips freeZKPassport from the type. We forward all
+// three sub-options so the iframe shows every Government ID card variant.
+export type PrivateRequestSBTArgs = RequestSBTExtraParams & {
+  kycOptions?: KycOptions;
+  cleanHandsOptions?: CleanHandsOptions;
+  paymentConfig?: PaymentConfig;
+};
+
 // Extended interface with secret methods that exist at runtime but aren't in the public interface
 export interface ExtendedHumanIDProvider extends HumanIDProviderInterface {
   getKeygenMessage(): string;
-  privateRequestSBT(type: CredentialType, args: RequestSBTExtraParams): Promise<RequestSBTResponse>;
+  privateRequestSBT(type: CredentialType, args: PrivateRequestSBTArgs): Promise<RequestSBTResponse>;
 }

--- a/platforms/src/HumanID/shared/utils.ts
+++ b/platforms/src/HumanID/shared/utils.ts
@@ -1,8 +1,28 @@
 import { initHumanID, CredentialType, SignProtocolAttestation } from "@holonym-foundation/human-id-sdk";
-import type { RequestSBTExtraParams, TransactionRequestWithChainId } from "@holonym-foundation/human-id-interface-core";
+import type {
+  RequestSBTExtraParams,
+  TransactionRequestWithChainId,
+  KycOptions,
+  CleanHandsOptions,
+  PaymentConfig,
+} from "@holonym-foundation/human-id-interface-core";
 import type { Address } from "viem";
+import axios from "axios";
 import { ProviderPayload } from "../../types.js";
 import { ExtendedHumanIDProvider } from "./types.js";
+
+// Free ZK Passport off-chain attestations live in id-server, keyed by wallet address,
+// with a 7-day lifetime. There is no SDK helper yet, so we hit id-server directly.
+// Production-only host; sandbox is intentionally not wired here.
+const ID_SERVER_BASE_URL = "https://id-server.holonym.io";
+
+export type ZkPassportOffChainAttestation = {
+  address: string;
+  attestationType: "zk-passport";
+  payload: { uniqueIdentifier: string };
+  issuedAt: string; // ISO timestamp
+  expiresAt: string; // ISO timestamp; issuedAt + 7 days
+};
 
 export function isHexString(value: string): value is `0x${string}` {
   return value.startsWith("0x");
@@ -38,6 +58,73 @@ export function validateSbt(
   return { valid: true };
 }
 
+/**
+ * Fetch the most recent free ZK Passport off-chain attestation for an address from id-server.
+ * Returns null when no attestation exists (HTTP 404). Throws on other non-2xx responses or
+ * malformed payloads — callers should not silently swallow those.
+ *
+ * Note: id-server returns the most recent attestation regardless of expiry. Callers must
+ * check `expiresAt > now` themselves (see validateOffChainAttestation).
+ */
+export async function getZkPassportFreeOffChainAttestation(
+  address: string
+): Promise<ZkPassportOffChainAttestation | null> {
+  const url = `${ID_SERVER_BASE_URL}/off-chain-attestations/zk-passport`;
+
+  let response;
+  try {
+    response = await axios.get(url, {
+      params: { address },
+      timeout: 10_000,
+      // We handle 404 ourselves; let axios throw on 5xx and other errors.
+      validateStatus: (status) => (status >= 200 && status < 300) || status === 404,
+    });
+  } catch (e) {
+    throw new Error(`Failed to fetch ZK Passport off-chain attestation: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  if (response.status === 404) return null;
+
+  const data = response.data;
+  if (
+    !data ||
+    typeof data !== "object" ||
+    typeof data.address !== "string" ||
+    data.attestationType !== "zk-passport" ||
+    typeof data.expiresAt !== "string" ||
+    typeof data.payload !== "object" ||
+    data.payload === null ||
+    typeof data.payload.uniqueIdentifier !== "string"
+  ) {
+    throw new Error("Malformed ZK Passport off-chain attestation response");
+  }
+
+  return data as ZkPassportOffChainAttestation;
+}
+
+export function validateOffChainAttestation(
+  attestation: ZkPassportOffChainAttestation | null
+): { valid: true; expiresAt: Date } | { valid: false; error: string } {
+  if (!attestation) {
+    return { valid: false, error: "Off-chain attestation not found" };
+  }
+
+  if (!attestation.payload?.uniqueIdentifier) {
+    return { valid: false, error: "Off-chain attestation missing uniqueIdentifier" };
+  }
+
+  const expiresAt = new Date(attestation.expiresAt);
+  if (isNaN(expiresAt.getTime())) {
+    return { valid: false, error: "Off-chain attestation has invalid expiresAt" };
+  }
+
+  if (expiresAt <= new Date()) {
+    return { valid: false, error: "Off-chain attestation has expired" };
+  }
+
+  return { valid: true, expiresAt };
+}
+
 export function validateAttestation(
   attestation: SignProtocolAttestation | null
 ): { valid: true } | { valid: false; error: string } {
@@ -62,6 +149,9 @@ export async function requestSBT({
   sendTransactionAsync,
   switchChainAsync,
   hasExistingCredential,
+  kycOptions,
+  cleanHandsOptions,
+  paymentConfig,
 }: {
   credentialType: CredentialType;
   address: Address;
@@ -77,6 +167,9 @@ export async function requestSBT({
   }) => Promise<`0x${string}`>;
   switchChainAsync: (params: { chainId: number }) => Promise<any>;
   hasExistingCredential?: (address: string) => Promise<boolean>;
+  kycOptions?: KycOptions;
+  cleanHandsOptions?: CleanHandsOptions;
+  paymentConfig?: PaymentConfig;
 }): Promise<ProviderPayload> {
   // Check if user already has a valid credential (SBT or attestation)
   if (hasExistingCredential && (await hasExistingCredential(address))) {
@@ -94,10 +187,18 @@ export async function requestSBT({
   // Request signature from user
   const signature = await signMessageAsync({ message });
 
-  // Prepare SBT request parameters
-  const requestParams: RequestSBTExtraParams = {
+  // Prepare SBT request parameters. kycOptions / cleanHandsOptions / paymentConfig
+  // forward to privateRequestSBT — the iframe shows the corresponding card variants.
+  const requestParams: RequestSBTExtraParams & {
+    kycOptions?: KycOptions;
+    cleanHandsOptions?: CleanHandsOptions;
+    paymentConfig?: PaymentConfig;
+  } = {
     signature,
     address: address,
+    kycOptions,
+    cleanHandsOptions,
+    paymentConfig,
     paymentCallback: async (tx: TransactionRequestWithChainId) => {
       const chainId = parseInt(tx.chainId, 16);
 

--- a/platforms/src/HumanIdKyc/App-Bindings.ts
+++ b/platforms/src/HumanIdKyc/App-Bindings.ts
@@ -1,24 +1,43 @@
 import React from "react";
 import { PlatformOptions } from "../types.js";
 import { BaseHumanIDPlatform } from "../HumanID/shared/BaseHumanIDPlatform.js";
-import { getKycSBTByAddress } from "@holonym-foundation/human-id-sdk";
+import { getKycSBTByAddress, getZkPassportSBTByAddress } from "@holonym-foundation/human-id-sdk";
+import type { KycOptions } from "@holonym-foundation/human-id-interface-core";
+import { getZkPassportFreeOffChainAttestation, validateOffChainAttestation } from "../HumanID/shared/utils.js";
 import { KYC_CREDENTIAL_TYPE } from "./constants.js";
 
 export class HumanIdKycPlatform extends BaseHumanIDPlatform {
   platformId = "HumanIdKyc";
   path = "HumanIdKyc";
   credentialType = KYC_CREDENTIAL_TYPE;
-  sbtFetcher = getKycSBTByAddress;
+
+  // Multi-source: any of three Human ID issuance paths counts as a valid Government ID
+  // credential. Order matches the backend provider in HumanIdKyc/Providers/humanIdKyc.ts.
+  sbtFetchers = [getKycSBTByAddress, getZkPassportSBTByAddress];
+
+  hasValidOffChainAttestation = async (address: string): Promise<boolean> => {
+    const attestation = await getZkPassportFreeOffChainAttestation(address);
+    return validateOffChainAttestation(attestation).valid;
+  };
+
+  // freeZKPassport is omitted from the public requestSBT type but accepted by
+  // privateRequestSBT at runtime — the cast in HumanID/shared/types.ts makes
+  // the unrestricted KycOptions reachable.
+  kycOptions: KycOptions = {
+    regularKYC: true,
+    paidZKPassport: true,
+    freeZKPassport: true,
+  };
 
   constructor(options: PlatformOptions) {
     super(options);
 
     this.banner = {
-      heading: "To add the Human ID KYC Stamp to your Passport...",
+      heading: "To add the Human ID Government ID Stamp to your Passport...",
       content: React.createElement(
         "div",
         {},
-        "Connect your wallet and complete identity verification privately through Human ID"
+        "Connect your wallet and verify your identity privately through Human ID. You can choose Onfido KYC ($5), the paid ZK Passport flow ($3), or the free ZK Passport flow (1-week off-chain attestation)."
       ),
       cta: {
         label: "Learn more",

--- a/platforms/src/HumanIdKyc/Providers/humanIdKyc.ts
+++ b/platforms/src/HumanIdKyc/Providers/humanIdKyc.ts
@@ -1,9 +1,53 @@
-import { BaseHumanIdProvider } from "../../HumanID/shared/BaseHumanIdProvider.js";
-import { getKycSBTByAddress } from "@holonym-foundation/human-id-sdk";
+import {
+  BaseHumanIdProvider,
+  CredentialSource,
+  CredentialSourceResult,
+  sbtSource,
+} from "../../HumanID/shared/BaseHumanIdProvider.js";
+import { getKycSBTByAddress, getZkPassportSBTByAddress } from "@holonym-foundation/human-id-sdk";
+import { getZkPassportFreeOffChainAttestation, validateOffChainAttestation } from "../../HumanID/shared/utils.js";
 import { KYC_CREDENTIAL_TYPE } from "../constants.js";
 
+/**
+ * Free ZK Passport off-chain attestation source. The attestation has a 7-day TTL,
+ * so we propagate the remaining lifetime as `expiresInSeconds` — the IAM credential
+ * issuer (identity/src/credentials.ts) clamps the VC's expirationDate accordingly.
+ */
+const zkPassportOffChainSource: CredentialSource = async (address): Promise<CredentialSourceResult> => {
+  const attestation = await getZkPassportFreeOffChainAttestation(address);
+  const result = validateOffChainAttestation(attestation);
+  if (!result.valid) return { valid: false, error: (result as any).error };
+
+  const expiresInSeconds = Math.floor((result.expiresAt.getTime() - Date.now()) / 1000);
+  return {
+    valid: true,
+    record: {
+      // attestation is non-null when validateOffChainAttestation says valid
+      nullifier: attestation!.payload.uniqueIdentifier,
+      sbtType: "zk-passport-offchain",
+    },
+    expiresInSeconds,
+  };
+};
+
+/**
+ * Government ID provider. Accepts any of three Human ID issuance paths:
+ *   1. Regular KYC SBT (Onfido, $5)
+ *   2. Paid ZK Passport SBT ($3) — V3ZKPassportSybilResistance
+ *   3. Free ZK Passport off-chain attestation (7-day TTL)
+ *
+ * Provider type stays "HolonymGovIdProvider" so existing scorer weights and stamps
+ * don't move. First valid source wins.
+ */
 export class HumanIdKycProvider extends BaseHumanIdProvider {
   type = "HolonymGovIdProvider";
-  sbtFetcher = getKycSBTByAddress;
   credentialType = KYC_CREDENTIAL_TYPE;
+
+  protected sources(): CredentialSource[] {
+    return [
+      sbtSource(getKycSBTByAddress),
+      sbtSource(getZkPassportSBTByAddress, { sbtType: "zk-passport-onchain" }),
+      zkPassportOffChainSource,
+    ];
+  }
 }

--- a/platforms/src/HumanIdKyc/__tests__/humanIdKyc.test.ts
+++ b/platforms/src/HumanIdKyc/__tests__/humanIdKyc.test.ts
@@ -1,0 +1,159 @@
+// ---- Test subject
+import { RequestPayload } from "@gitcoin/passport-types";
+import axios from "axios";
+import { HumanIdKycProvider } from "../Providers/humanIdKyc.js";
+import { getKycSBTByAddress, getZkPassportSBTByAddress, setOptimismRpcUrl } from "@holonym-foundation/human-id-sdk";
+
+// Mock the SDK
+jest.mock("@holonym-foundation/human-id-sdk", () => ({
+  getKycSBTByAddress: jest.fn(),
+  getZkPassportSBTByAddress: jest.fn(),
+  setOptimismRpcUrl: jest.fn(),
+}));
+
+// Mock axios for the off-chain attestation HTTP call
+jest.mock("axios");
+
+const mockedGetKycSBT = getKycSBTByAddress as jest.MockedFunction<typeof getKycSBTByAddress>;
+const mockedGetZkpSBT = getZkPassportSBTByAddress as jest.MockedFunction<typeof getZkPassportSBTByAddress>;
+const mockedSetRpcUrl = setOptimismRpcUrl as jest.MockedFunction<typeof setOptimismRpcUrl>;
+const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios.get>;
+
+const MOCK_ADDRESS = "0xb4b6f1c68be31841b52f4015a31d1f38b99cdb71";
+
+const validSbt = (nullifier: string) =>
+  Promise.resolve({
+    expiry: BigInt(Math.floor(Date.now() / 1000) + 3600),
+    publicValues: [BigInt(1), BigInt(2), BigInt(3), BigInt(nullifier), BigInt(5)],
+    revoked: false,
+  } as any);
+
+const offChainResponse = (expiresAt: Date, uniqueIdentifier = "uid-abc") => ({
+  status: 200,
+  data: {
+    address: MOCK_ADDRESS.toLowerCase(),
+    attestationType: "zk-passport",
+    payload: { uniqueIdentifier },
+    issuedAt: new Date(expiresAt.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    expiresAt: expiresAt.toISOString(),
+  },
+});
+
+const offChainNotFound = () => Promise.resolve({ status: 404, data: { code: "NOT_FOUND" } });
+
+describe("HumanIdKycProvider (Government ID, multi-source)", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    originalEnv = process.env;
+    process.env = { ...originalEnv, OPTIMISM_RPC_URL: "https://test-rpc.optimism.io" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns valid when only the regular KYC SBT exists", async () => {
+    mockedGetKycSBT.mockReturnValueOnce(validSbt("11111"));
+    mockedGetZkpSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    mockedAxiosGet.mockResolvedValueOnce(offChainNotFound());
+
+    const result = await new HumanIdKycProvider().verify({ address: MOCK_ADDRESS } as RequestPayload);
+
+    expect(mockedSetRpcUrl).toHaveBeenCalledWith("https://test-rpc.optimism.io");
+    expect(result.valid).toBe(true);
+    expect(result.record).toEqual({ nullifier: "11111" });
+    expect(result.expiresInSeconds).toBeUndefined();
+    // Short-circuits — does not call later sources
+    expect(mockedGetZkpSBT).not.toHaveBeenCalled();
+    expect(mockedAxiosGet).not.toHaveBeenCalled();
+  });
+
+  it("returns valid when only the paid ZK Passport SBT exists", async () => {
+    mockedGetKycSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    mockedGetZkpSBT.mockReturnValueOnce(validSbt("22222"));
+
+    const result = await new HumanIdKycProvider().verify({ address: MOCK_ADDRESS } as RequestPayload);
+
+    expect(result.valid).toBe(true);
+    expect(result.record).toEqual({ nullifier: "22222", sbtType: "zk-passport-onchain" });
+    expect(result.expiresInSeconds).toBeUndefined();
+    expect(mockedAxiosGet).not.toHaveBeenCalled();
+  });
+
+  it("returns valid with off-chain attestation only, with expiresInSeconds clamped to attestation TTL", async () => {
+    mockedGetKycSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    mockedGetZkpSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    // 1 day from now
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    mockedAxiosGet.mockResolvedValueOnce(offChainResponse(expiresAt, "uid-1day"));
+
+    const result = await new HumanIdKycProvider().verify({ address: MOCK_ADDRESS } as RequestPayload);
+
+    expect(result.valid).toBe(true);
+    expect(result.record).toEqual({ nullifier: "uid-1day", sbtType: "zk-passport-offchain" });
+    // Allow a small fudge (test execution time)
+    expect(result.expiresInSeconds).toBeGreaterThanOrEqual(86_390);
+    expect(result.expiresInSeconds).toBeLessThanOrEqual(86_400);
+  });
+
+  it("off-chain attestation valid 6 days in returns ~1 day expiry", async () => {
+    mockedGetKycSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    mockedGetZkpSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    // issued 6 days ago, expires in 1 day
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    mockedAxiosGet.mockResolvedValueOnce(offChainResponse(expiresAt));
+
+    const result = await new HumanIdKycProvider().verify({ address: MOCK_ADDRESS } as RequestPayload);
+
+    expect(result.valid).toBe(true);
+    expect(result.expiresInSeconds).toBeGreaterThanOrEqual(86_390);
+    expect(result.expiresInSeconds).toBeLessThanOrEqual(86_400);
+  });
+
+  it("prefers SBT-based sources when multiple credentials exist (no expiry override)", async () => {
+    mockedGetKycSBT.mockReturnValueOnce(validSbt("33333"));
+    // ZK Passport SBT and off-chain attestation also exist, but should not be reached
+    mockedGetZkpSBT.mockReturnValueOnce(validSbt("44444"));
+    mockedAxiosGet.mockResolvedValueOnce(offChainResponse(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)));
+
+    const result = await new HumanIdKycProvider().verify({ address: MOCK_ADDRESS } as RequestPayload);
+
+    expect(result.valid).toBe(true);
+    expect(result.record).toEqual({ nullifier: "33333" });
+    expect(result.expiresInSeconds).toBeUndefined();
+    expect(mockedGetZkpSBT).not.toHaveBeenCalled();
+    expect(mockedAxiosGet).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid when no source has a valid credential", async () => {
+    mockedGetKycSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    mockedGetZkpSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    mockedAxiosGet.mockResolvedValueOnce(offChainNotFound());
+
+    const result = await new HumanIdKycProvider().verify({ address: MOCK_ADDRESS } as RequestPayload);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(/^kyc /);
+  });
+
+  it("treats an expired off-chain attestation as invalid", async () => {
+    mockedGetKycSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    mockedGetZkpSBT.mockRejectedValueOnce(new Error("SBT not found"));
+    // Already expired
+    mockedAxiosGet.mockResolvedValueOnce(offChainResponse(new Date(Date.now() - 60_000)));
+
+    const result = await new HumanIdKycProvider().verify({ address: MOCK_ADDRESS } as RequestPayload);
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects malformed addresses without calling any source", async () => {
+    const result = new HumanIdKycProvider().verify({ address: "not-an-address" } as RequestPayload);
+    await expect(result).rejects.toThrow("Invalid address format");
+    expect(mockedGetKycSBT).not.toHaveBeenCalled();
+    expect(mockedGetZkpSBT).not.toHaveBeenCalled();
+    expect(mockedAxiosGet).not.toHaveBeenCalled();
+  });
+});

--- a/platforms/src/HumanIdKyc/__tests__/humanIdKycPlatform.test.ts
+++ b/platforms/src/HumanIdKyc/__tests__/humanIdKycPlatform.test.ts
@@ -1,0 +1,55 @@
+// Verifies the HumanIdKycPlatform forwards kycOptions (including freeZKPassport)
+// to privateRequestSBT — the central premise of Goal 1.
+import { HumanIdKycPlatform } from "../App-Bindings.js";
+
+const mockPrivateRequestSBT = jest.fn();
+const mockGetKeygenMessage = jest.fn(() => "test-keygen-message");
+
+jest.mock("@holonym-foundation/human-id-sdk", () => ({
+  initHumanID: jest.fn(() => ({
+    getKeygenMessage: mockGetKeygenMessage,
+    privateRequestSBT: mockPrivateRequestSBT,
+  })),
+  setOptimismRpcUrl: jest.fn(),
+  getKycSBTByAddress: jest.fn().mockRejectedValue(new Error("SBT not found")),
+  getZkPassportSBTByAddress: jest.fn().mockRejectedValue(new Error("SBT not found")),
+}));
+
+// Block the off-chain attestation HTTP call by faking a 404.
+jest.mock("axios", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(async () => ({ status: 404, data: { code: "NOT_FOUND" } })),
+  },
+}));
+
+describe("HumanIdKycPlatform", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrivateRequestSBT.mockResolvedValue({
+      sbt: { recipient: "0xrecipient", txHash: "0xhash", chain: "Optimism" },
+    });
+  });
+
+  it("forwards kycOptions with all three flags to privateRequestSBT", async () => {
+    const platform = new HumanIdKycPlatform({});
+
+    await platform.getProviderPayload({
+      address: "0x1234567890123456789012345678901234567890" as `0x${string}`,
+      signMessageAsync: jest.fn(async () => "0xsignature"),
+      sendTransactionAsync: jest.fn(),
+      switchChainAsync: jest.fn(),
+    } as any);
+
+    expect(mockPrivateRequestSBT).toHaveBeenCalledTimes(1);
+    const [credentialType, params] = mockPrivateRequestSBT.mock.calls[0];
+    expect(credentialType).toBe("kyc");
+    expect(params.kycOptions).toEqual({
+      regularKYC: true,
+      paidZKPassport: true,
+      freeZKPassport: true,
+    });
+    expect(params.cleanHandsOptions).toBeUndefined();
+    expect(params.signature).toBe("0xsignature");
+  });
+});

--- a/platforms/src/__mocks__/@holonym-foundation/human-id-sdk.ts
+++ b/platforms/src/__mocks__/@holonym-foundation/human-id-sdk.ts
@@ -80,6 +80,16 @@ export const getKycSBTByAddress = jest.fn(async (address: string): Promise<SBTRe
   };
 });
 
+export const getZkPassportSBTByAddress = jest.fn(async (_address: string): Promise<SBTResult | null> => null);
+
+export const uncheckedGetMinimalZkPassportSBTByAddress = jest.fn(
+  async (_address: string): Promise<{ address: string } | null> => null
+);
+
+export const getCleanHandsSPAttestationByAddress = jest.fn(
+  async (_address: string): Promise<{ indexingValue: string } | null> => null
+);
+
 export const uncheckedGetMinimalPhoneSBTByAddress = jest.fn(async (address: string) => {
   if (!address) {
     return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,15 +5508,15 @@
   resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.2.0.tgz#0c05124af50434a800773abec8d3af6a297d904b"
   integrity sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==
 
-"@holonym-foundation/human-id-interface-core@0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@holonym-foundation/human-id-interface-core/-/human-id-interface-core-0.0.13.tgz#63f05e777c7366dfb9ff30e72d056177160a8ef4"
-  integrity sha512-I36d5YZQCKSVPLzGjFo8JJXeFlntP4mEtJzXFC5sfr6vCPFHzoyR6KVF0hC8Kx+EbUj6Vnsdd5DiT+475WqOVw==
-
 "@holonym-foundation/human-id-interface-core@0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@holonym-foundation/human-id-interface-core/-/human-id-interface-core-0.0.9.tgz#0354e58b9ba61e5691989781bd9b2b8086d09c55"
   integrity sha512-Yaz3047jznZuaqMjyFck/lUbUp68E1VXHHKsHAvWtBytoC0Ql5h2HKyrYQ9k39/uS+H3l3BFNB6oF/MxnDPECw==
+
+"@holonym-foundation/human-id-interface-core@0.2.0", "@holonym-foundation/human-id-interface-core@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@holonym-foundation/human-id-interface-core/-/human-id-interface-core-0.2.0.tgz#610996e5c937491277e8cc9459620d4c275e35c5"
+  integrity sha512-c8tzbpc//ghQYnUaePxQuMJSQ3sszmJrrS6A1pyYWQwAme7fo80CQqfW8NhnQU8ZvjgPbYAu4hFYMKBIltWfSw==
 
 "@holonym-foundation/human-id-sdk@^0.0.17":
   version "0.0.17"
@@ -5532,12 +5532,12 @@
     zod "^3.21.4"
     zod-validation-error "^1.3.0"
 
-"@holonym-foundation/human-id-sdk@^0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@holonym-foundation/human-id-sdk/-/human-id-sdk-0.0.24.tgz#765e588c9f5fbca01a2b8e0464b71b1e8da2b8e7"
-  integrity sha512-rThdO6ujyLHsozk3bFujD8QdN5Aln/Uq4gm9mpvpDf7jS4JJXGhYYncjlSmBVCWMnKkIz2gnT+T1oZQxFd3o0w==
+"@holonym-foundation/human-id-sdk@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@holonym-foundation/human-id-sdk/-/human-id-sdk-0.3.0.tgz#31fc87efe5d4dae7842d7b40b63233c99000710c"
+  integrity sha512-QPSlRllEI3XmrmuSyzaAjbZQThEl4ndf26Msw9dR9LhQ0R3vtIMmIYo5Ol8iBCOIw+UJPWBafUEyhQWPQGgkNQ==
   dependencies:
-    "@holonym-foundation/human-id-interface-core" "0.0.13"
+    "@holonym-foundation/human-id-interface-core" "0.2.0"
     "@metamask/rpc-errors" "^5.1.1"
     "@walletconnect/ethereum-provider" "^2.20.2"
     events "^3.3.0"


### PR DESCRIPTION
## Summary

Adds ZK Passport support to Human ID-based stamps (Government ID + Clean Hands) by bumping `@holonym-foundation/human-id-sdk` to 0.3 and wiring new iframe options + multi-source verification.

## Changes

**Government ID** — `HolonymGovIdProvider` becomes multi-source, returning the first valid credential from:
1. Regular KYC SBT (Onfido) — default expiry
2. Paid ZK Passport SBT — default expiry; `sbtType=zk-passport-onchain`
3. Free ZK Passport off-chain attestation — `expiresInSeconds` clamped to attestation TTL; `sbtType=zk-passport-offchain`

The off-chain attestation is fetched directly from id-server (no SDK helper yet); 404 = no attestation, other non-2xx throw. Remaining lifetime flows through `VerifiedPayload.expiresInSeconds` to the issued VC's `expirationDate` via existing plumbing in `identity/src/credentials.ts`. Provider type stays `HolonymGovIdProvider` so scorer weights don't move. Frontend `hasExistingCredential` mirrors the same source order.

`BaseHumanIdProvider` gains a `CredentialSource` abstraction; existing single-source subclasses (Phone, Biometrics) work unchanged via a default `sources()` that wraps `sbtFetcher`.

**Iframe options** — `HumanIdKycPlatform` sets `kycOptions = { regularKYC, paidZKPassport, freeZKPassport }` to surface all three Gov ID cards. `freeZKPassport` is stripped from the public `requestSBT` type but accepted by `privateRequestSBT`; the local `ExtendedHumanIDProvider` cast carries the unrestricted `KycOptions` through.

**Clean Hands** — `CleanHandsPlatform` sets `cleanHandsOptions = { regularKYC: true, zkPassport: true }` to surface both Onfido and ZK Passport branches. Credential shape is identical across branches, so `getCleanHandsSPAttestationByAddress` covers both — no provider change.

**Deps** — bumps `@holonym-foundation/human-id-sdk` to `^0.3.0`; adds `@holonym-foundation/human-id-interface-core ^0.2.0` for `KycOptions` / `CleanHandsOptions` / `PaymentConfig` types.

## Test plan
- [ ] Gov ID issues from each of the three sources, with off-chain expiry clamped to attestation TTL
- [ ] All three cards appear in the Gov ID iframe; both cards appear in the Clean Hands iframe
- [ ] Phone and Biometrics stamps still work unchanged
