### PR TITLE
fix(platforms): forward HumanID iframe options from guide buttons

### DIFF
--- a/platforms/src/CleanHands/App-Bindings.tsx
+++ b/platforms/src/CleanHands/App-Bindings.tsx
@@ -2,8 +2,7 @@
 import React from "react";
 import { BaseHumanIDPlatform } from "../HumanID/shared/BaseHumanIDPlatform.js";
 import { getCleanHandsSPAttestationByAddress } from "@holonym-foundation/human-id-sdk";
-import type { CleanHandsOptions } from "@holonym-foundation/human-id-interface-core";
-import { CLEAN_HANDS_CREDENTIAL_TYPE } from "./constants.js";
+import { CLEAN_HANDS_CREDENTIAL_TYPE, CLEAN_HANDS_OPTIONS } from "./constants.js";
 import { Hyperlink } from "../utils/Hyperlink.js";
 
 export class CleanHandsPlatform extends BaseHumanIDPlatform {
@@ -12,13 +11,7 @@ export class CleanHandsPlatform extends BaseHumanIDPlatform {
   credentialType = CLEAN_HANDS_CREDENTIAL_TYPE;
   attestationFetcher = getCleanHandsSPAttestationByAddress; // Note: attestation, not SBT
 
-  // Show both the Onfido card and the ZK Passport card in the Human ID iframe.
-  // The ZK Passport branch issues to the same Sign Protocol schema, so the
-  // existing attestationFetcher covers both branches.
-  cleanHandsOptions: CleanHandsOptions = {
-    regularKYC: true,
-    zkPassport: true,
-  };
+  cleanHandsOptions = CLEAN_HANDS_OPTIONS;
 
   banner = {
     content: (

--- a/platforms/src/CleanHands/Providers-config.ts
+++ b/platforms/src/CleanHands/Providers-config.ts
@@ -1,6 +1,7 @@
 import { PlatformSpec, PlatformGroupSpec, Provider } from "../types.js";
 import { CleanHandsProvider } from "./Providers/index.js";
 import { requestSBT } from "../HumanID/shared/utils.js";
+import { CLEAN_HANDS_OPTIONS } from "./constants.js";
 
 export const PlatformDetails: PlatformSpec = {
   icon: "./assets/cleanHands.svg",
@@ -31,6 +32,7 @@ export const PlatformDetails: PlatformSpec = {
                   signMessageAsync,
                   sendTransactionAsync,
                   switchChainAsync,
+                  cleanHandsOptions: CLEAN_HANDS_OPTIONS,
                 });
               },
             },

--- a/platforms/src/CleanHands/constants.ts
+++ b/platforms/src/CleanHands/constants.ts
@@ -1,3 +1,12 @@
 import { CredentialType } from "@holonym-foundation/human-id-sdk";
+import type { CleanHandsOptions } from "@holonym-foundation/human-id-interface-core";
 
 export const CLEAN_HANDS_CREDENTIAL_TYPE: CredentialType = "clean-hands";
+
+// Show both the Onfido card and the ZK Passport card in the Human ID iframe.
+// The ZK Passport branch issues to the same Sign Protocol schema, so the
+// existing attestationFetcher covers both branches.
+export const CLEAN_HANDS_OPTIONS: CleanHandsOptions = {
+  regularKYC: true,
+  zkPassport: true,
+};

--- a/platforms/src/HumanIdKyc/App-Bindings.ts
+++ b/platforms/src/HumanIdKyc/App-Bindings.ts
@@ -2,9 +2,8 @@ import React from "react";
 import { PlatformOptions } from "../types.js";
 import { BaseHumanIDPlatform } from "../HumanID/shared/BaseHumanIDPlatform.js";
 import { getKycSBTByAddress, getZkPassportSBTByAddress } from "@holonym-foundation/human-id-sdk";
-import type { KycOptions } from "@holonym-foundation/human-id-interface-core";
 import { getZkPassportFreeOffChainAttestation, validateOffChainAttestation } from "../HumanID/shared/utils.js";
-import { KYC_CREDENTIAL_TYPE } from "./constants.js";
+import { KYC_CREDENTIAL_TYPE, KYC_OPTIONS } from "./constants.js";
 
 export class HumanIdKycPlatform extends BaseHumanIDPlatform {
   platformId = "HumanIdKyc";
@@ -20,14 +19,7 @@ export class HumanIdKycPlatform extends BaseHumanIDPlatform {
     return validateOffChainAttestation(attestation).valid;
   };
 
-  // freeZKPassport is omitted from the public requestSBT type but accepted by
-  // privateRequestSBT at runtime — the cast in HumanID/shared/types.ts makes
-  // the unrestricted KycOptions reachable.
-  kycOptions: KycOptions = {
-    regularKYC: true,
-    paidZKPassport: true,
-    freeZKPassport: true,
-  };
+  kycOptions = KYC_OPTIONS;
 
   constructor(options: PlatformOptions) {
     super(options);

--- a/platforms/src/HumanIdKyc/Providers-config.ts
+++ b/platforms/src/HumanIdKyc/Providers-config.ts
@@ -1,6 +1,7 @@
 import { PlatformSpec, PlatformGroupSpec, Provider } from "../types.js";
 import { HumanIdKycProvider } from "./Providers/humanIdKyc.js";
 import { requestSBT } from "../HumanID/shared/utils.js";
+import { KYC_OPTIONS } from "./constants.js";
 
 export const PlatformDetails: PlatformSpec = {
   icon: "./assets/idCard.svg",
@@ -32,6 +33,7 @@ export const PlatformDetails: PlatformSpec = {
                   signMessageAsync,
                   sendTransactionAsync,
                   switchChainAsync,
+                  kycOptions: KYC_OPTIONS,
                 });
               },
             },

--- a/platforms/src/HumanIdKyc/constants.ts
+++ b/platforms/src/HumanIdKyc/constants.ts
@@ -1,3 +1,13 @@
 import { CredentialType } from "@holonym-foundation/human-id-sdk";
+import type { KycOptions } from "@holonym-foundation/human-id-interface-core";
 
 export const KYC_CREDENTIAL_TYPE: CredentialType = "kyc";
+
+// freeZKPassport is omitted from the public requestSBT type but accepted by
+// privateRequestSBT at runtime — the cast in HumanID/shared/types.ts makes
+// the unrestricted KycOptions reachable.
+export const KYC_OPTIONS: KycOptions = {
+  regularKYC: true,
+  paidZKPassport: true,
+  freeZKPassport: true,
+};


### PR DESCRIPTION
The "Verify Identity" / "Verify Clean Hands" buttons in each stamp's
guide call requestSBT directly and were not passing kycOptions /
cleanHandsOptions, so the Human ID iframe fell back to its default card
set. Only the "Check Eligibility" path (which goes through
BaseHumanIDPlatform.getProviderPayload) forwarded the configured
options, which meant the iframe showed different card variants
depending on entry point — notably hiding the free/paid ZK Passport
cards on Government ID and the ZK Passport card on Clean Hands.

Extract the option objects into each platform's constants module and
import them from both App-Bindings and Providers-config so both entry
points configure the iframe identically.

Closes https://github.com/holonym-foundation/internal-docs/issues/947.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
