### PR TITLE
feat(analytics): add PostHog frontend instrumentation (Analytics M2)

### DIFF
--- a/app/components/GenericPlatform.tsx
+++ b/app/components/GenericPlatform.tsx
@@ -4,6 +4,9 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 // --- Datadog
 import { datadogLogs } from "@datadog/browser-logs";
 
+// --- Analytics
+import posthog from "posthog-js";
+
 // --- Identity tools
 import {
   CredentialResponseBody,
@@ -145,6 +148,7 @@ export const GenericPlatform = ({
   // fetch VCs from IAM server
   const handleFetchCredential = async (): Promise<void> => {
     datadogLogs.logger.info("Saving Stamp", { platform: platform.platformId });
+    posthog.capture("cta_clicked", { site: "passport.human.tech", cta_id: "verify_stamp", platform: platform.platformId });
     setLoading(true);
     const selectedProviders = platformProviderIds;
 

--- a/app/components/GenericPlatform.tsx
+++ b/app/components/GenericPlatform.tsx
@@ -148,7 +148,11 @@ export const GenericPlatform = ({
   // fetch VCs from IAM server
   const handleFetchCredential = async (): Promise<void> => {
     datadogLogs.logger.info("Saving Stamp", { platform: platform.platformId });
-    posthog.capture("cta_clicked", { site: "passport.human.tech", cta_id: "verify_stamp", platform: platform.platformId });
+    posthog.capture("cta_clicked", {
+      site: "passport.human.tech",
+      cta_id: "verify_stamp",
+      platform: platform.platformId,
+    });
     setLoading(true);
     const selectedProviders = platformProviderIds;
 

--- a/app/context/datastoreConnectionContext.tsx
+++ b/app/context/datastoreConnectionContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useMemo, useCallback } 
 import { datadogRum } from "@datadog/browser-rum";
 import { SiweMessage } from "siwe";
 import axios from "axios";
+import posthog from "posthog-js";
 
 import { CERAMIC_CACHE_ENDPOINT } from "../config/stamp_config";
 import { updateIntercomUserData } from "../hooks/useIntercom";
@@ -169,6 +170,7 @@ export const useDatastoreConnection = () => {
         setDbAccessToken(existingToken);
         setDbAccessTokenStatus("connected");
         setUserAddress(address);
+        posthog.identify(address);
 
         // Set up session validity check
         setCheckSessionIsValid(() => () => isTokenValid(existingToken));
@@ -187,6 +189,7 @@ export const useDatastoreConnection = () => {
       setDbAccessToken(dbAccessToken);
       setDbAccessTokenStatus("connected");
       setUserAddress(address);
+      posthog.identify(address);
 
       // Set up session validity check
       setCheckSessionIsValid(() => () => isTokenValid(dbAccessToken));

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
     "react-confetti": "^6.1.0",
     "react-dom": "^18.3.1",
     "react-google-login": "^5.2.2",
+    "posthog-js": "^1.240.4",
     "react-gtm-module": "^2.0.11",
     "react-responsive": "^10.0.0",
     "react-router-dom": "^6.22.3",

--- a/app/pages/Home.tsx
+++ b/app/pages/Home.tsx
@@ -1,5 +1,5 @@
 // --- React Methods
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 // --- Components
 import SIWEButton from "../components/SIWEButton";
@@ -9,6 +9,9 @@ import { DEFAULT_CUSTOMIZATION_KEY, useCustomization } from "../hooks/useCustomi
 
 import { useLoginFlow } from "../hooks/useLoginFlow";
 import { InitialScreenWelcome } from "../components/InitialScreenLayout";
+
+// --- Analytics
+import posthog from "posthog-js";
 
 export default function Home() {
   const { isLoggingIn, signIn, loginStep } = useLoginFlow();
@@ -20,6 +23,11 @@ export default function Home() {
     const usingCustomization = customization.key !== DEFAULT_CUSTOMIZATION_KEY;
     setEnableEthBranding(!usingCustomization);
   }, [customization.key]);
+
+  const handleConnectWallet = useCallback(() => {
+    posthog.capture("cta_clicked", { site: "passport.human.tech", cta_id: "connect_wallet" });
+    signIn();
+  }, [signIn]);
 
   // customization.scorer?.weights
 
@@ -45,7 +53,7 @@ export default function Home() {
           isLoading={isLoggingIn}
           enableEthBranding={enableEthBranding}
           data-testid="connectWalletButton"
-          onClick={signIn}
+          onClick={handleConnectWallet}
           className="px-10 mmb-12 md:w-2/3"
         />
       </div>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -15,6 +15,9 @@ import { ScorerContextProvider } from "../context/scorerContext";
 // --- GTM Module
 import TagManager from "react-gtm-module";
 
+// --- Analytics
+import posthog from "posthog-js";
+
 import { themes, ThemeWrapper } from "../utils/theme";
 import { StampClaimingContextProvider } from "../context/stampClaimingContext";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -23,6 +26,14 @@ import { Web3Context, Web3ErrorContext } from "../hooks/Web3Context";
 import { AutoVerificationProvider } from "../components/AutoVerificationProvider";
 
 const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID || "";
+
+// Initialize PostHog (client-side only)
+if (typeof window !== "undefined") {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.i.posthog.com",
+    person_profiles: "identified_only",
+  });
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Summary

This is **Analytics M2** from Human Tech's analytics PRD — adding PostHog frontend instrumentation to passport.human.tech.

- **PostHog init** in `_app.tsx` — EU ingest host, `identified_only` person profiles
- **User identification** — `posthog.identify(walletAddress)` fires in `datastoreConnectionContext` the moment a session becomes connected (both new sign-in and session resumption from localStorage)
- **CTA tracking** — explicit `cta_clicked` events on:
  - `connect_wallet` — the "Connect your wallet" button on the Home page (`pages/Home.tsx`)
  - `verify_stamp` — the "Verify" button in the stamp drawer (`components/GenericPlatform.tsx`), includes `platform` property
- **Pageviews** — handled automatically by PostHog autocapture (no manual instrumentation needed)
- **posthog-js** added to `app/package.json` as `^1.240.4`

## Env vars required in Vercel

```
NEXT_PUBLIC_POSTHOG_KEY=phc_wQgJt8dm2pAJih49fwRXRxR3hY4VbKVpjfa9XqGLknJK
NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
```

## Test plan

- [ ] Add the two env vars above to the Vercel project for passport.human.tech
- [ ] Deploy and visit passport.human.tech
- [ ] Open PostHog → Live Events (project 185989, eu.posthog.com) — confirm `$pageview` events appear
- [ ] Click "Connect your wallet" on the home page — confirm `cta_clicked` event with `cta_id: connect_wallet`
- [ ] Complete wallet connection and confirm `$identify` event fires with the wallet address as distinct ID
- [ ] Open a stamp drawer and click Verify — confirm `cta_clicked` with `cta_id: verify_stamp` and the `platform` property set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)