### PR TITLE
fix(app): use plain script tag for Iris chat widget

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -6,7 +6,6 @@ import { BroadcastChannel } from "broadcast-channel";
 // --- Next Methods
 import { AppProps } from "next/app";
 import Head from "next/head";
-import Script from "next/script";
 
 import "../styles/globals.css";
 import { CeramicContextProvider } from "../context/ceramicContext";
@@ -135,11 +134,8 @@ function App({ Component, pageProps }: AppProps) {
           </DatastoreConnectionContextProvider>
         </QueryClientProvider>
       </Web3Context>
-      <Script
-        src="https://iris-v2-fqgd.onrender.com/widget/iris-widget.js"
-        data-iris-key="passport"
-        strategy="afterInteractive"
-      />
+      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+      <script src="https://iris-v2-fqgd.onrender.com/widget/iris-widget.js" data-iris-key="passport" async />
     </>
   );
 }


### PR DESCRIPTION
## Summary

The Iris chat bubble on app.passport.xyz shows "Support is temporarily unavailable" because the Next.js `<Script strategy="afterInteractive">` component breaks the widget's initialization.

**Root cause:** When loaded via Next.js `<Script>`, `document.currentScript` is `null` (async execution), and the `data-iris-key` attribute query fails due to timing. This means the widget can't resolve its API base URL, so all API calls fail silently.

**Fix:** Use a plain `<script async>` tag instead, matching how the working sites (support.passport.human.tech, support.waap.xyz) load the widget.

## Changes
- Replaced `<Script strategy="afterInteractive">` with `<script async />`
- Removed unused `next/script` import

## Test plan
- [ ] Iris chat bubble appears on app.passport.xyz
- [ ] Clicking the bubble opens the chat panel
- [ ] Sending a message gets a response

🤖 Generated with [Claude Code](https://claude.com/claude-code)