### PR TITLE
feat(analytics): behavioral analytics layer — heatmaps + replay-by-surface

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -28,10 +28,36 @@ import { AutoVerificationProvider } from "../components/AutoVerificationProvider
 const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID || "";
 
 // Initialize PostHog (client-side only)
+//
+// Behavioral analytics standard: heatmaps, scroll, and click maps plus autocapture
+// are enabled across every surface. Session replay is gated by surface type.
+//
+// Surface decision: app.passport.xyz (wallet / KYC / PII flows) and
+// passport.human.tech (marketing landing) are served from this single Next.js SPA
+// with one shared init and no clean route boundary that guarantees a wallet-free
+// surface — the landing page (Home) itself hosts the SIWE connect-wallet button.
+// Per the analytics standard we therefore default the whole app to the APP profile:
+// session replay is DISABLED so we never record wallet / KYC sessions. Enabling
+// masked replay on the marketing pages requires host/route separation and is a
+// follow-up.
 if (typeof window !== "undefined") {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.i.posthog.com",
     person_profiles: "identified_only",
+    autocapture: true,
+    capture_pageview: true,
+    capture_pageleave: true,
+    enable_heatmaps: true,
+    // APP profile — safety first: never record wallet / KYC sessions.
+    disable_session_recording: true,
+  });
+
+  // Register the behavioral-analytics dimensions as super properties so they ride
+  // along on autocapture, pageview, and heatmap events.
+  posthog.register({
+    site: "passport",
+    product: "passport",
+    surface_type: "app",
   });
 }
 


### PR DESCRIPTION
## What changed

Upgrades the **existing** PostHog init in `app/pages/_app.tsx` (no second init) to the Human Tech behavioral analytics standard:

- `autocapture: true`
- `capture_pageview: true`
- `capture_pageleave: true` (scroll depth)
- `enable_heatmaps: true` (click maps + scroll maps + click maps everywhere)
- `disable_session_recording: true` (see decision below)

Adds `posthog.register({ site, product, surface_type })` so these dimensions ride along on autocapture, pageview, and heatmap events.

Existing `person_profiles: "identified_only"`, `posthog.identify(address)`, and the per-event `posthog.capture("cta_clicked", ...)` calls are **unchanged**.

## Replay-by-surface decision: APP-only default

The spec describes two surfaces:
- **app.passport.xyz** (wallet / KYC / PII flows) → APP profile, **no replay**
- **passport.human.tech** (marketing landing) → CONTENT profile, masked replay on

In this repo both surfaces are served from a **single Next.js SPA** with **one shared client-side init** in `_app.tsx`. There is no clean route/build boundary that guarantees a wallet-free surface — the marketing landing page (`pages/Home.tsx`) itself hosts the SIWE connect-wallet button, so even the "landing" transitions straight into the wallet flow on the same build/domain.

Per the standard's explicit decision rule (same SPA / no clear route boundary → **default to the APP profile for the whole thing, safety first, never record wallet/KYC sessions**), this PR sets:

- `disable_session_recording: true`
- `surface_type: 'app'`

**Follow-up:** enabling masked replay (`disable_session_recording: false` + `session_recording: { maskAllInputs: true, maskTextSelector: '[data-ph-mask]' }`, `surface_type: 'marketing'`) on the marketing pages requires host/route separation — e.g. gate via `window.location.hostname` at init, or call `posthog.startSessionRecording()` only on confirmed marketing-only routes. Deferred so we never accidentally record wallet sessions.

## site / surface_type values

| property | value |
|----------|-------|
| `site` | `passport` |
| `product` | `passport` |
| `surface_type` | `app` |

## Verification

- posthog-js `^1.240.4`: confirmed all five config options (`autocapture`, `capture_pageview`, `capture_pageleave`, `enable_heatmaps`, `disable_session_recording`) and `register()` exist in the shipped type defs — edit is type-correct.
- `prettier --check app/pages/_app.tsx` passes with the repo's config (printWidth 120). Full monorepo install/build not run (heavy); change is a config-only edit to one file.

Implements holonym-foundation/internal-docs#1521 (spec PR #1522)

🤖 Generated with [Claude Code](https://claude.com/claude-code)